### PR TITLE
feat: Optimize media viewer for large libraries

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
 <script>
     'use strict';
     let mediaFiles=[],mediaIndex=new Map(),initialViewHistory=[],sessionViewedPrefixes=new Set(),rotationAngle=0,zoomScale=1,imgOffsetX=0,imgOffsetY=0,isDragging=!1,dragStartX=0,dragStartY=0,dragStartOffsetX=0,dragStartOffsetY=0,isLoading=!1,currentOperationController=null,allSelectedFiles=null,rootDirName='',iconBlobUrls=new Map(),faviconBlobUrl=null,speedDialConfig=[];
+    let worker; // Web Worker instance
     let coverOverlayBlur,coverOverlay,mediaContainerEl,loadingIndicatorEl,newMediaButton,themeToggleButton,speedDialContainerEl,selectNucleoButtonEl,speedDialOptionsEl,speedDialStatusEl,faviconElement,folderInputEl,fullscreenMediaEl,fullscreenImgEl,fullscreenVideoEl,rotateButtonEl,searchInputEl,searchSuggestionsEl,draggedItemOriginalName=null,returnToSpeedDialButton, controlsContainerEl;
     let luckyFeatureContainerEl, luckyImageWrapperEl, luckyImageEl, luckyImageTextEl;
     let currentLuckyFileItem=null, luckyImageBlobUrl=null, luckyFeatureState='initial';
@@ -68,27 +69,247 @@
 
     const THUMB_ANIM_DELAY_STAGGER=90,COVER_DISPLAY_DELAY=1500,MAX_FILTERED_ITEMS=25,MAX_INITIAL_ITEMS=32,INITIAL_HISTORY_SIZE_LIMIT=MAX_INITIAL_ITEMS*3,ORIGINAIS_FOLDER_NAME='originais',CAPAS_FOLDER_NAME='.capas',CAMINHO_FOLDER_NAMES=Array.from({length:25},(_,i)=>`Caminho ${i+1}`),MAX_SEARCH_SUGGESTIONS=10,MIN_ZOOM=.1,MAX_ZOOM=20,ZOOM_SENSITIVITY=1.1;
     const ICON_NAME_REGEX = /^(icon\d+|fav)\.(jpe?g|png|avif)$/i;
+    // Constants for worker communication - ensure these match worker.js if passed or used for checks
+    const MEDIA_FILE_EXTENSIONS_WORKER = ['.mp4', '.mkv', '.avi', '.mov', '.wmv', '.flv', '.webm', '.mpeg', '.mpg', '.m4v', '.jpg', '.jpeg', '.png', '.gif', '.avif'];
+
 
     const delay=(m,s)=>new Promise((r,j)=>{if(s?.aborted)return j(new DOMException('Delay cancelled before start','AbortError'));const l=()=>{clearTimeout(t);j(new DOMException('Delay cancelled','AbortError'))},t=setTimeout(()=>{s?.removeEventListener('abort',l);r()},m);s?.addEventListener('abort',l,{once:!0})});
-    function isMediaFile(f){return /\.(jpe?g|png|gif|mp4|mkv|webm|avif)$/i.test(f)}
+    function isMediaFile(f){return /\.(jpe?g|png|gif|mp4|mkv|webm|avif)$/i.test(f)} // Used for UI/display logic on main thread
     function isImageFile(f){return /\.(jpe?g|png|gif|avif)$/i.test(f)}
     function getRandomMedia(m,c){const s=[...m],l=s.length,n=Math.min(c,l);if(n===0)return[];for(let i=l-1;i>=l-n;i--){const k=Math.floor(Math.random()*(i+1));[s[i],s[k]]=[s[k],s[i]]}return s.slice(l-n)}
     function getFirstTwoWords(f){if(!f)return'';const n=f.substring(0,f.lastIndexOf('.'))||f,w=n.split(/[\s_.-]+/).filter(Boolean);return w.slice(0,2).join(' ').trim()||n}
-    function revokeItemResources(i){if(!i)return;if(i.blobUrl?.startsWith('blob:')){try{URL.revokeObjectURL(i.blobUrl)}catch(e){}}i.blobUrl=null;i.fileRef=null;i.loadSuccess=null;i.abortController?.abort();i.abortController=null}
+    function revokeItemResources(itemMeta){ // itemMeta is metadata from worker
+        if(!itemMeta)return;
+        if(itemMeta.blobUrl?.startsWith('blob:')){
+            try{URL.revokeObjectURL(itemMeta.blobUrl)}catch(e){}
+        }
+        itemMeta.blobUrl=null;
+        // itemMeta.fileRef=null; // fileRef is now looked up from allSelectedFiles when needed, not stored on itemMeta long-term
+        itemMeta.loadSuccess=null;
+        // itemMeta.abortController is not a property of worker-derived metadata
+    }
     function getRandomInitialMedia(availableFiles,count){if(!availableFiles||availableFiles.length===0)return[];const historySet=new Set(initialViewHistory);let eligibleFiles=availableFiles.filter(f=>f.relativePath&&!historySet.has(f.relativePath));if(eligibleFiles.length===0&&availableFiles.length>0){eligibleFiles=[...availableFiles]}if(eligibleFiles.length===0)return[];const prefixToFileMap=new Map();for(const file of eligibleFiles){if(!file.prefix)continue;if(!prefixToFileMap.has(file.prefix)){prefixToFileMap.set(file.prefix,[])}prefixToFileMap.get(file.prefix).push(file)}if(prefixToFileMap.size===0){const fallbackSelected=getRandomMedia(eligibleFiles,count);const fallbackPaths=fallbackSelected.map(f=>f.relativePath).filter(Boolean);initialViewHistory.unshift(...fallbackPaths);if(initialViewHistory.length>INITIAL_HISTORY_SIZE_LIMIT){initialViewHistory.length=INITIAL_HISTORY_SIZE_LIMIT}for(const file of fallbackSelected){if(file.prefix){sessionViewedPrefixes.add(file.prefix)}}return fallbackSelected}let G_eligiblePrefixes=Array.from(prefixToFileMap.keys());let H_preferredPrefixes=G_eligiblePrefixes.filter(p=>!sessionViewedPrefixes.has(p));let I_prefixesToUseThisRound;if(H_preferredPrefixes.length>0){I_prefixesToUseThisRound=H_preferredPrefixes}else{sessionViewedPrefixes.clear();I_prefixesToUseThisRound=G_eligiblePrefixes}for(let i=I_prefixesToUseThisRound.length-1;i>0;i--){const j=Math.floor(Math.random()*(i+1));[I_prefixesToUseThisRound[i],I_prefixesToUseThisRound[j]]=[I_prefixesToUseThisRound[j],I_prefixesToUseThisRound[i]]}const resultFiles=[];const selectedRelativePathsThisRun=new Set();for(const prefix of I_prefixesToUseThisRound){if(resultFiles.length>=count)break;const filesForThisPrefix=prefixToFileMap.get(prefix);if(filesForThisPrefix&&filesForThisPrefix.length>0){const K_availableFilesInPrefix=filesForThisPrefix.filter(f=>!selectedRelativePathsThisRun.has(f.relativePath));if(K_availableFilesInPrefix.length>0){const L_randomIndex=Math.floor(Math.random()*K_availableFilesInPrefix.length);const M_selectedFile=K_availableFilesInPrefix[L_randomIndex];resultFiles.push(M_selectedFile);selectedRelativePathsThisRun.add(M_selectedFile.relativePath);sessionViewedPrefixes.add(M_selectedFile.prefix)}}}if(resultFiles.length<count){const N_remainingEligibleFiles=eligibleFiles.filter(f=>!selectedRelativePathsThisRun.has(f.relativePath));if(N_remainingEligibleFiles.length>0){const O_neededCount=count-resultFiles.length;const P_additionalFiles=getRandomMedia(N_remainingEligibleFiles,O_neededCount);for(const file of P_additionalFiles){if(resultFiles.length>=count)break;resultFiles.push(file);selectedRelativePathsThisRun.add(file.relativePath);if(file.prefix)sessionViewedPrefixes.add(file.prefix)}}}const Q_resultPaths=resultFiles.map(f=>f.relativePath).filter(Boolean);initialViewHistory.unshift(...Q_resultPaths);if(initialViewHistory.length>INITIAL_HISTORY_SIZE_LIMIT){initialViewHistory.length=INITIAL_HISTORY_SIZE_LIMIT}return resultFiles}
     function setSpeedDialStatus(m,e=!1){if(!speedDialStatusEl)return;speedDialStatusEl.textContent=m;speedDialStatusEl.classList.toggle('error',e)}
-    function beginOperation(){if(currentOperationController){currentOperationController.abort()}currentOperationController=new AbortController();isLoading=!0;if(selectNucleoButtonEl)selectNucleoButtonEl.disabled=!0;if(newMediaButton)newMediaButton.disabled=!0;if(themeToggleButton)themeToggleButton.disabled=!0;if(searchInputEl)searchInputEl.disabled=!0;if(returnToSpeedDialButton)returnToSpeedDialButton.disabled=!0;if(speedDialOptionsEl){speedDialOptionsEl.querySelectorAll('.speed-dial-item').forEach(i=>{i.style.pointerEvents='none';i.setAttribute('aria-disabled','true')})}return currentOperationController.signal}
-    function endOperation(s=!0){if(!isLoading&&!currentOperationController)return;isLoading=!1;currentOperationController=null;if(selectNucleoButtonEl)selectNucleoButtonEl.disabled=!1;const i=!document.body.classList.contains('initial-load')&&(!speedDialContainerEl||speedDialContainerEl.style.display==='none');if(returnToSpeedDialButton){returnToSpeedDialButton.style.display=i?'inline-block':'none';returnToSpeedDialButton.disabled=!1}if(i){const h=mediaFiles.some(t=>!t.isCoverFile),c=mediaFiles.some(t=>t.isCoverFile);if(searchInputEl)searchInputEl.disabled=!(allSelectedFiles&&c);if(newMediaButton){newMediaButton.style.display=h?'inline-block':'none';newMediaButton.disabled=!h}if(controlsContainerEl) controlsContainerEl.style.display = 'flex';
+    function beginOperation(){if(currentOperationController){currentOperationController.abort(); console.log("Main: Previous operation controller aborted.")}currentOperationController=new AbortController();isLoading=!0;if(selectNucleoButtonEl)selectNucleoButtonEl.disabled=!0;if(newMediaButton)newMediaButton.disabled=!0;if(themeToggleButton)themeToggleButton.disabled=!0;if(searchInputEl)searchInputEl.disabled=!0;if(returnToSpeedDialButton)returnToSpeedDialButton.disabled=!0;if(speedDialOptionsEl){speedDialOptionsEl.querySelectorAll('.speed-dial-item').forEach(i=>{i.style.pointerEvents='none';i.setAttribute('aria-disabled','true')})}return currentOperationController.signal}
+    function endOperation(s=!0){if(!isLoading&&!currentOperationController&&s)return;isLoading=!1;currentOperationController=null;if(selectNucleoButtonEl)selectNucleoButtonEl.disabled=!1;const i=!document.body.classList.contains('initial-load')&&(!speedDialContainerEl||speedDialContainerEl.style.display==='none');if(returnToSpeedDialButton){returnToSpeedDialButton.style.display=i?'inline-block':'none';returnToSpeedDialButton.disabled=!1}if(i){const h=mediaFiles.some(t=>!t.isCoverFile),c=mediaFiles.some(t=>t.isCoverFile);if(searchInputEl)searchInputEl.disabled=!(allSelectedFiles&&c);if(newMediaButton){newMediaButton.style.display=h?'inline-block':'none';newMediaButton.disabled=!h}if(controlsContainerEl) controlsContainerEl.style.display = 'flex';
     }else{if(newMediaButton)newMediaButton.style.display='none';if(searchInputEl)searchInputEl.disabled=!0;if(controlsContainerEl) controlsContainerEl.style.display = 'none'; hideCaminhoSidebar(); 
     }if(themeToggleButton)themeToggleButton.disabled=!1;if(allSelectedFiles&&speedDialOptionsEl){speedDialOptionsEl.querySelectorAll('.speed-dial-item').forEach(t=>{t.style.pointerEvents='auto';t.removeAttribute('aria-disabled')})}}
     function cleanupUIState(){clearTimeout(window.coverDisplayTimeoutId||0);if(coverOverlayBlur){coverOverlayBlur.classList.remove('visible');coverOverlayBlur.style.backgroundImage='none'}if(coverOverlay){coverOverlay.classList.remove('visible');coverOverlay.style.backgroundImage='none'}if(document.body)document.body.classList.remove('cover-active');if(mediaContainerEl){mediaContainerEl.innerHTML='';mediaContainerEl.classList.remove('view-initial','view-filtered')}if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(searchSuggestionsEl){searchSuggestionsEl.innerHTML='';searchSuggestionsEl.style.display='none'}if(searchInputEl)searchInputEl.value=''; hideCaminhoSidebar();}
-    function buildMediaIndex(s){if(s.aborted)throw new DOMException('Index cancelled','AbortError');const i=isLoading;isLoading=!0;mediaIndex.clear();for(let k=0;k<mediaFiles.length;k++){if(k%500===0&&s.aborted){mediaIndex.clear();isLoading=i;throw new DOMException('Index aborted during build','AbortError')}const t=mediaFiles[k],p=t.prefix?.toLowerCase();if(!p)continue;if(!mediaIndex.has(p)){mediaIndex.set(p,{covers:[],regulars:[]})}const e=mediaIndex.get(p);(t.isCoverFile?e.covers:e.regulars).push(t)}isLoading=i}
-    async function ensureFileObjectForItem(i,s){if(s?.aborted)throw new DOMException('Cancelled during file check','AbortError');if(i.fileRef instanceof File){const x=i.name.split('.').pop()?.toLowerCase()||'',t={'jpg':'image/jpeg','jpeg':'image/jpeg','png':'image/png','gif':'image/gif','mp4':'video/mp4','webm':'video/webm','mkv':'video/x-matroska','avif':'image/avif'};i.type=t[x]||i.fileRef.type||'application/octet-stream';return!0}else{i.loadSuccess=!1;i.type='error/missing-ref';console.warn(`Missing file reference for item: ${i.name}`);return!1}}
-    async function loadBlobForItem(i,s){if(s?.aborted)throw new DOMException('Cancelled before blob load','AbortError');if(i.blobUrl&&i.loadSuccess===!0)return!0;if(i.loadSuccess===!1)return!1;i.abortController?.abort();i.abortController=new AbortController();const t=i.abortController.signal,c=AbortSignal.any?AbortSignal.any([s,t].filter(Boolean)):(s||t);i.loadSuccess='pending';try{if(!await ensureFileObjectForItem(i,c)){i.loadSuccess=!1;return!1}const f=i.fileRef;if(!f)throw new Error("Missing file reference unexpectedly");if(c?.aborted)throw new DOMException('Cancelled before blob creation','AbortError');if(i.blobUrl&&i.blobUrl.startsWith('blob:')){try{URL.revokeObjectURL(i.blobUrl)}catch(e){}}i.blobUrl=URL.createObjectURL(f);if(c?.aborted){URL.revokeObjectURL(i.blobUrl);i.blobUrl=null;throw new DOMException('Cancelled after blob creation','AbortError')}i.loadSuccess=!0;return!0}catch(e){if(e.name==='AbortError'){i.loadSuccess=null;i.blobUrl=null;if(i.blobUrl?.startsWith('blob:'))try{URL.revokeObjectURL(i.blobUrl)}catch(x){}}else{console.error("Error creating blob for",i.name,e);i.loadSuccess=!1;i.blobUrl=null}return!1}finally{i.abortController=null}}
-    async function loadCoverImageBlobUrl(i,s){if(s?.aborted)throw new DOMException('Cancelled loading cover blob','AbortError');if(!i?.isCoverFile)return null;try{return await loadBlobForItem(i,s)?i.blobUrl:null}catch(e){if(e.name==='AbortError')throw e;console.error("Non-abort error loading cover blob:",i.name,e);return null}}
-    function buildMediaElement(i){if(!i||i.isCoverFile)return null;const d=document.createElement('div');d.className='media-container-item';if(i.isOriginal){d.classList.add('is-original');const l=document.createElement('span');l.className='original-label';l.textContent='Original';d.appendChild(l)}const c=document.createElement('p');c.onclick=e=>{e.stopPropagation();if(!isLoading)displayGlobalMediaByPrefix(i.prefix)};c.title=i.name;let m;if(i.loadSuccess===!0&&i.blobUrl){if(i.type?.startsWith('image')){m=document.createElement('img');m.src=i.blobUrl;m.alt=i.name;m.loading='lazy'}else if(i.type?.startsWith('video')){m=document.createElement('video');m.src=i.blobUrl;m.muted=!0;m.preload='metadata';m.playsInline=!0}if(m){m.className='media-item';m.onclick=e=>{e.stopPropagation();showFullscreenMedia(i.blobUrl,i.type)};m.onerror=()=>{const p=document.createElement('div');p.className='media-error-placeholder';p.textContent='Render Err';if(m.parentNode)m.parentNode.replaceChild(p,m);i.loadSuccess=!1;revokeItemResources(i);c.textContent=`${i.prefix||'?'} (Render Err)`;d.classList.add('has-error')}}}if(!m){m=document.createElement('div');m.className='media-error-placeholder';let e="Erro";switch(i.loadSuccess){case!1:e=i.type==='error/missing-ref'?'No Ref':(i.type==='error/access'?'No Access':'Load Fail');break;case'pending':e='Carregando...';break;case null:e='Not Loaded';break}m.textContent=e;c.textContent=`${i.prefix||'?'} (${e})`;d.classList.add('has-error')}d.appendChild(m);c.textContent=c.textContent||i.prefix||'?';d.appendChild(c);return d}
-    async function ensureMediaReadyAndBuildElement(i,s){if(s.aborted)throw new DOMException('Cancelled before ensuring media readiness','AbortError');if(!i||i.isCoverFile)return null;if(!i.blobUrl&&i.loadSuccess!==!1){try{await loadBlobForItem(i,s)}catch(e){if(e.name==='AbortError')throw e}}if(s.aborted)throw new DOMException('Cancelled after trying to load blob','AbortError');return buildMediaElement(i)}
-    async function displayMedia(m,s,l){if(s.aborted)return;if(!mediaContainerEl)return;mediaContainerEl.innerHTML='';mediaContainerEl.classList.remove('view-initial','view-filtered');mediaContainerEl.classList.add(l?'view-initial':'view-filtered');mediaContainerEl.style.display='block';const t=(m||[]).filter(i=>!i.isCoverFile);if(t.length===0){const e="text-align: center; width: 100%; column-span: all; padding: 20px 0;";if(!document.body.classList.contains('cover-active')){mediaContainerEl.innerHTML=`<p style="${e}">Nenhum item encontrado para exibir.</p>`}return}let a=[];const n=()=>a.forEach(clearTimeout);s.addEventListener('abort',n,{once:!0});const o=t.map(i=>ensureMediaReadyAndBuildElement(i,s)),r=(await Promise.allSettled(o)).filter(p=>p.status==='fulfilled'&&p.value).map(p=>p.value);if(!s.aborted&&r.length>0){const f=document.createDocumentFragment();r.forEach(e=>f.appendChild(e));mediaContainerEl.appendChild(f);r.forEach((e,d)=>{const p=setTimeout(()=>{if(!s.aborted&&e.isConnected){e.classList.add('visible')}},d*THUMB_ANIM_DELAY_STAGGER);a.push(p)})}else if(!s.aborted&&r.length===0&&t.length>0){const e="color:var(--error-text); text-align: center; width: 100%; column-span: all; padding: 20px 0;";mediaContainerEl.innerHTML=`<p style="${e}">Erro ao carregar itens de mídia.</p>`}s.removeEventListener('abort',n)}
+    
+    // buildMediaIndex is now in worker.js
+    // async function ensureFileObjectForItem is effectively replaced by logic within loadBlobForItem
+    // It used to check i.fileRef, now loadBlobForItem finds the File object from allSelectedFiles.
+
+    async function loadBlobForItem(itemMeta, signal) { // itemMeta is metadata from worker
+        if (signal?.aborted) throw new DOMException('Cancelled before blob load', 'AbortError');
+
+        // If blob already exists and was successfully loaded, return true.
+        // Note: itemMeta on main thread won't have blobUrl/loadSuccess initially.
+        // These checks are more for items that might be re-processed or if we add caching here.
+        if (itemMeta.blobUrl && itemMeta.loadSuccess === true) return true;
+        if (itemMeta.loadSuccess === false) return false; // Previously failed
+
+        // The worker doesn't send abortController, this is for main-thread operations if any.
+        // itemMeta.abortController?.abort(); 
+        // itemMeta.abortController = new AbortController();
+        // const localSignal = itemMeta.abortController.signal;
+        // const combinedSignal = AbortSignal.any ? AbortSignal.any([signal, localSignal].filter(Boolean)) : (signal || localSignal);
+        const combinedSignal = signal; // For now, just use the passed signal
+
+        itemMeta.loadSuccess = 'pending';
+
+        try {
+            if (!allSelectedFiles) {
+                throw new Error("allSelectedFiles is not populated on main thread.");
+            }
+            let fileRef = null;
+            for (let i = 0; i < allSelectedFiles.length; i++) {
+                if (allSelectedFiles[i].webkitRelativePath === itemMeta.relativePath) {
+                    fileRef = allSelectedFiles[i];
+                    break;
+                }
+            }
+
+            if (!fileRef) {
+                throw new Error(`File not found in allSelectedFiles for path: ${itemMeta.relativePath}`);
+            }
+            // itemMeta.fileRef = fileRef; // Don't store fileRef directly on itemMeta to avoid cloning issues if itemMeta is passed around more.
+                                       // It's looked up when needed.
+
+            const fileExtension = itemMeta.name.split('.').pop()?.toLowerCase() || '';
+            const mimeTypes = {'jpg':'image/jpeg','jpeg':'image/jpeg','png':'image/png','gif':'image/gif','mp4':'video/mp4','webm':'video/webm','mkv':'video/x-matroska','avif':'image/avif'};
+            itemMeta.type = mimeTypes[fileExtension] || fileRef.type || 'application/octet-stream';
+
+
+            if (combinedSignal?.aborted) throw new DOMException('Cancelled before blob creation', 'AbortError');
+
+            // Revoke old blob URL if one exists for this item (e.g. if re-loading)
+            if (itemMeta.blobUrl && itemMeta.blobUrl.startsWith('blob:')) {
+                try { URL.revokeObjectURL(itemMeta.blobUrl); } catch (e) { /* ignore */ }
+            }
+            
+            itemMeta.blobUrl = URL.createObjectURL(fileRef); // Use the looked-up fileRef
+
+            if (combinedSignal?.aborted) {
+                URL.revokeObjectURL(itemMeta.blobUrl);
+                itemMeta.blobUrl = null;
+                throw new DOMException('Cancelled after blob creation', 'AbortError');
+            }
+            itemMeta.loadSuccess = true;
+            return true;
+        } catch (e) {
+            if (e.name === 'AbortError') {
+                itemMeta.loadSuccess = null; // Reset state
+            } else {
+                console.error("Error creating blob for", itemMeta.name, e);
+                itemMeta.loadSuccess = false;
+            }
+            if (itemMeta.blobUrl?.startsWith('blob:')) { // Clean up if blob was created before abort/error
+                try { URL.revokeObjectURL(itemMeta.blobUrl); } catch (x) { /* ignore */ }
+            }
+            itemMeta.blobUrl = null;
+            // itemMeta.abortController = null; // Not used this way anymore
+            return false;
+        }
+    }
+
+    async function loadCoverImageBlobUrl(itemMeta,signal){ // itemMeta from worker
+        if(signal?.aborted)throw new DOMException('Cancelled loading cover blob','AbortError');
+        if(!itemMeta?.isCoverFile)return null;
+        try{
+            // Ensure itemMeta itself is updated with blobUrl if successful
+            const success = await loadBlobForItem(itemMeta, signal); 
+            return success ? itemMeta.blobUrl : null;
+        }catch(e){
+            if(e.name==='AbortError')throw e;
+            console.error("Non-abort error loading cover blob:",itemMeta.name,e);
+            return null
+        }
+    }
+
+    function buildMediaElement(itemMeta){ // itemMeta from worker, potentially updated by loadBlobForItem
+        if(!itemMeta||itemMeta.isCoverFile)return null;
+        const d=document.createElement('div');
+        d.className='media-container-item';
+        if(itemMeta.isOriginal){
+            d.classList.add('is-original');
+            const l=document.createElement('span');
+            l.className='original-label';
+            l.textContent='Original';
+            d.appendChild(l)
+        }
+        const c=document.createElement('p');
+        c.onclick=e=>{e.stopPropagation();if(!isLoading)displayGlobalMediaByPrefix(itemMeta.prefix)};
+        c.title=itemMeta.name;
+        let m;
+        if(itemMeta.loadSuccess===true&&itemMeta.blobUrl){ // Check itemMeta for blobUrl and success
+            if(itemMeta.type?.startsWith('image')){
+                m=document.createElement('img');
+                m.src=itemMeta.blobUrl;
+                m.alt=itemMeta.name;
+                m.loading='lazy'
+            }else if(itemMeta.type?.startsWith('video')){
+                m=document.createElement('video');
+                m.src=itemMeta.blobUrl;
+                m.muted=!0;
+                m.preload='metadata';
+                m.playsInline=!0
+            }
+            if(m){
+                m.className='media-item';
+                m.onclick=e=>{e.stopPropagation();showFullscreenMedia(itemMeta.blobUrl,itemMeta.type)};
+                m.onerror=()=>{
+                    const p=document.createElement('div');
+                    p.className='media-error-placeholder';
+                    p.textContent='Render Err';
+                    if(m.parentNode)m.parentNode.replaceChild(p,m);
+                    itemMeta.loadSuccess=false; // Update the item's state
+                    // No revokeItemResources here, blob management is slightly different
+                    c.textContent=`${itemMeta.prefix||'?'} (Render Err)`;
+                    d.classList.add('has-error')
+                }
+            }
+        }
+        if(!m){
+            m=document.createElement('div');
+            m.className='media-error-placeholder';
+            let e="Erro";
+            switch(itemMeta.loadSuccess){
+                case false:e=itemMeta.type==='error/missing-ref'?'No Ref':(itemMeta.type==='error/access'?'No Access':'Load Fail');break;
+                case'pending':e='Carregando...';break;
+                case null:e='Not Loaded';break
+            }
+            m.textContent=e;
+            c.textContent=`${itemMeta.prefix||'?'} (${e})`;
+            d.classList.add('has-error')
+        }
+        d.appendChild(m);
+        c.textContent=c.textContent||itemMeta.prefix||'?';
+        d.appendChild(c);
+        return d
+    }
+
+    async function ensureMediaReadyAndBuildElement(itemMeta,signal){ // itemMeta from worker
+        if(signal.aborted)throw new DOMException('Cancelled before ensuring media readiness','AbortError');
+        if(!itemMeta||itemMeta.isCoverFile)return null;
+        
+        // if itemMeta doesn't have blobUrl or load was not successful, try to load it.
+        if(!itemMeta.blobUrl || itemMeta.loadSuccess !== true){
+            try{
+                await loadBlobForItem(itemMeta,signal); // This will update itemMeta with blobUrl and loadSuccess
+            }catch(e){
+                if(e.name==='AbortError')throw e;
+                // Error already logged by loadBlobForItem
+            }
+        }
+        if(signal.aborted)throw new DOMException('Cancelled after trying to load blob','AbortError');
+        return buildMediaElement(itemMeta) // itemMeta should now have blobUrl if successful
+    }
+
+    async function displayMedia(mediaItemsMetadata,signal,isInitialView){ // mediaItemsMetadata is from worker
+        if(signal.aborted)return;
+        if(!mediaContainerEl)return;
+        mediaContainerEl.innerHTML='';
+        mediaContainerEl.classList.remove('view-initial','view-filtered');
+        mediaContainerEl.classList.add(isInitialView?'view-initial':'view-filtered');
+        mediaContainerEl.style.display='block';
+        
+        const itemsToDisplayMeta=(mediaItemsMetadata||[]).filter(i=>!i.isCoverFile);
+        
+        if(itemsToDisplayMeta.length===0){
+            const e="text-align: center; width: 100%; column-span: all; padding: 20px 0;";
+            if(!document.body.classList.contains('cover-active')){
+                mediaContainerEl.innerHTML=`<p style="${e}">Nenhum item encontrado para exibir.</p>`
+            }
+            return
+        }
+        
+        let animationTimeouts=[];
+        const clearAnimationTimeouts=()=>animationTimeouts.forEach(clearTimeout);
+        signal.addEventListener('abort',clearAnimationTimeouts,{once:!0});
+        
+        const mediaElementPromises=itemsToDisplayMeta.map(itemMeta=>ensureMediaReadyAndBuildElement(itemMeta,signal));
+        const settledElements=(await Promise.allSettled(mediaElementPromises))
+            .filter(p=>p.status==='fulfilled'&&p.value)
+            .map(p=>p.value);
+            
+        if(!signal.aborted&&settledElements.length>0){
+            const fragment=document.createDocumentFragment();
+            settledElements.forEach(el=>fragment.appendChild(el));
+            mediaContainerEl.appendChild(fragment);
+            
+            settledElements.forEach((el,idx)=>{
+                const timeoutId=setTimeout(()=>{
+                    if(!signal.aborted&&el.isConnected){ el.classList.add('visible') }
+                },idx*THUMB_ANIM_DELAY_STAGGER);
+                animationTimeouts.push(timeoutId);
+            });
+        }else if(!signal.aborted&&settledElements.length===0&&itemsToDisplayMeta.length>0){
+            const e="color:var(--error-text); text-align: center; width: 100%; column-span: all; padding: 20px 0;";
+            mediaContainerEl.innerHTML=`<p style="${e}">Erro ao carregar itens de mídia.</p>`
+        }
+        signal.removeEventListener('abort',clearAnimationTimeouts);
+    }
     
     // Funções para Instagram Link
     function getInstagramUsername(fileName) {
@@ -117,30 +338,81 @@
         }
     }
 
-    async function displayFilteredMedia(p){if(!p||isLoading)return;if(searchInputEl&&searchInputEl.value)searchInputEl.value='';if(searchSuggestionsEl){searchSuggestionsEl.innerHTML='';searchSuggestionsEl.style.display='none'}const s=beginOperation();let c=null;let coverItemName = null; try{
+    async function displayFilteredMedia(prefixToFilter){if(!prefixToFilter||isLoading)return;if(searchInputEl&&searchInputEl.value)searchInputEl.value='';if(searchSuggestionsEl){searchSuggestionsEl.innerHTML='';searchSuggestionsEl.style.display='none'}const s=beginOperation();let c=null;let coverItemName = null; try{
         updateMainHeader('Random Media'); // Reset header
         resetLuckyFeature();if(speedDialContainerEl) speedDialContainerEl.style.display = 'none';
         hideCaminhoSidebar(); 
-        clearTimeout(window.coverDisplayTimeoutId||0);if(coverOverlayBlur){coverOverlayBlur.classList.remove('visible');coverOverlayBlur.style.backgroundImage='none'}if(coverOverlay){coverOverlay.classList.remove('visible');coverOverlay.style.backgroundImage='none'}if(document.body)document.body.classList.remove('cover-active');if(loadingIndicatorEl){loadingIndicatorEl.textContent=`Filtrando por "${p}"...`;loadingIndicatorEl.style.display='block'}if(s.aborted)throw new DOMException('Cancelled early','AbortError');const e=mediaIndex.get(p.toLowerCase());if(!e||(!e.regulars?.length&&!e.covers?.length)){console.warn(`Prefix "${p}" not found in index.`);if(mediaContainerEl)mediaContainerEl.style.display='none';if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Prefixo "${p}" não encontrado na pasta selecionada. Tente outro.`,!1);endOperation(!0);return}const o=e.covers||[];let r=e.regulars||[];if(r.length>MAX_FILTERED_ITEMS){r=getRandomMedia(r,MAX_FILTERED_ITEMS)}if(r.length===0){console.warn(`No regular media found for prefix "${p}", only covers or empty regulars list.`);if(coverOverlayBlur){coverOverlayBlur.classList.remove('visible');coverOverlayBlur.style.backgroundImage='none'}if(coverOverlay){coverOverlay.classList.remove('visible');coverOverlay.style.backgroundImage='none'}if(document.body)document.body.classList.remove('cover-active');if(mediaContainerEl){mediaContainerEl.innerHTML='';mediaContainerEl.style.display='none'}if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Nenhum item regular encontrado para "${p}" neste Caminho. Selecione outro.`,!1);endOperation(!0);return}if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(mediaContainerEl)mediaContainerEl.style.display='block';if(controlsContainerEl)controlsContainerEl.style.display='flex';document.body.classList.remove('initial-load');if(o.length>0){const u=o.filter(i=>i.loadSuccess!==!1);if(u.length>0){const t=u[Math.floor(Math.random()*u.length)];c=await loadCoverImageBlobUrl(t,s); coverItemName = t.name;}}
+        clearTimeout(window.coverDisplayTimeoutId||0);if(coverOverlayBlur){coverOverlayBlur.classList.remove('visible');coverOverlayBlur.style.backgroundImage='none'}if(coverOverlay){coverOverlay.classList.remove('visible');coverOverlay.style.backgroundImage='none'}if(document.body)document.body.classList.remove('cover-active');if(loadingIndicatorEl){loadingIndicatorEl.textContent=`Filtrando por "${prefixToFilter}"...`;loadingIndicatorEl.style.display='block'}if(s.aborted)throw new DOMException('Cancelled early','AbortError');const e=mediaIndex.get(prefixToFilter.toLowerCase());if(!e||(!e.regulars?.length&&!e.covers?.length)){console.warn(`Prefix "${prefixToFilter}" not found in index.`);if(mediaContainerEl)mediaContainerEl.style.display='none';if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Prefixo "${prefixToFilter}" não encontrado na pasta selecionada. Tente outro.`,!1);endOperation(!0);return}const o=e.covers||[];let r=e.regulars||[];if(r.length>MAX_FILTERED_ITEMS){r=getRandomMedia(r,MAX_FILTERED_ITEMS)}if(r.length===0){console.warn(`No regular media found for prefix "${prefixToFilter}", only covers or empty regulars list.`);if(coverOverlayBlur){coverOverlayBlur.classList.remove('visible');coverOverlayBlur.style.backgroundImage='none'}if(coverOverlay){coverOverlay.classList.remove('visible');coverOverlay.style.backgroundImage='none'}if(document.body)document.body.classList.remove('cover-active');if(mediaContainerEl){mediaContainerEl.innerHTML='';mediaContainerEl.style.display='none'}if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Nenhum item regular encontrado para "${prefixToFilter}" neste Caminho. Selecione outro.`,!1);endOperation(!0);return}if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(mediaContainerEl)mediaContainerEl.style.display='block';if(controlsContainerEl)controlsContainerEl.style.display='flex';document.body.classList.remove('initial-load');if(o.length>0){const u=o.filter(i=>i.loadSuccess!==!1);if(u.length>0){const t=u[Math.floor(Math.random()*u.length)];c=await loadCoverImageBlobUrl(t,s); coverItemName = t.name;}}
         
         if (coverItemName) { // Update header if cover is shown
             const username = getInstagramUsername(coverItemName);
             if (username) updateMainHeader('@' + username);
         }
 
-        if(s.aborted)throw new DOMException('Cancelled during cover load','AbortError');if(c){if(coverOverlayBlur){coverOverlayBlur.style.backgroundImage=`url('${c}')`;requestAnimationFrame(()=>{if(!s.aborted)coverOverlayBlur.classList.add('visible')})}if(coverOverlay){coverOverlay.style.backgroundImage=`url('${c}')`;requestAnimationFrame(()=>{if(!s.aborted)coverOverlay.classList.add('visible')})}if(document.body&&!s.aborted)document.body.classList.add('cover-active');window.coverDisplayTimeoutId=setTimeout(async()=>{if(s.aborted)return;try{await displayMedia(r,s,!1);endOperation(!0)}catch(d){if(d.name!=='AbortError'){console.error("Error during post-cover media display:",d);setSpeedDialStatus(`Erro ao exibir mídia para "${p}" após a capa.`,!0)}endOperation(!1)}},COVER_DISPLAY_DELAY)}else{await displayMedia(r,s,!1);endOperation(!0)}}catch(e){if(e.name!=='AbortError'){console.error(`Error filtering for prefix "${p}":`,e);if(mediaContainerEl)mediaContainerEl.style.display='none';if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Erro ao filtrar por "${p}". Verifique o console.`,!0);endOperation(!1)}else{console.log(`Filtering for "${p}" was cancelled.`);if(!isLoading){cleanupUIState();if(speedDialContainerEl)speedDialContainerEl.style.display='flex';if(controlsContainerEl)controlsContainerEl.style.display='none';if(document.body)document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Filtragem por "${p}" cancelada.`,!1);endOperation(!1)}}if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(document.body&&!document.body.classList.contains('cover-active')){document.body.classList.remove('cover-active')}}}
+        if(s.aborted)throw new DOMException('Cancelled during cover load','AbortError');if(c){if(coverOverlayBlur){coverOverlayBlur.style.backgroundImage=`url('${c}')`;requestAnimationFrame(()=>{if(!s.aborted)coverOverlayBlur.classList.add('visible')})}if(coverOverlay){coverOverlay.style.backgroundImage=`url('${c}')`;requestAnimationFrame(()=>{if(!s.aborted)coverOverlay.classList.add('visible')})}if(document.body&&!s.aborted)document.body.classList.add('cover-active');window.coverDisplayTimeoutId=setTimeout(async()=>{if(s.aborted)return;try{await displayMedia(r,s,!1);endOperation(!0)}catch(d){if(d.name!=='AbortError'){console.error("Error during post-cover media display:",d);setSpeedDialStatus(`Erro ao exibir mídia para "${prefixToFilter}" após a capa.`,!0)}endOperation(!1)}},COVER_DISPLAY_DELAY)}else{await displayMedia(r,s,!1);endOperation(!0)}}catch(e){if(e.name!=='AbortError'){console.error(`Error filtering for prefix "${prefixToFilter}":`,e);if(mediaContainerEl)mediaContainerEl.style.display='none';if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Erro ao filtrar por "${prefixToFilter}". Verifique o console.`,!0);endOperation(!1)}else{console.log(`Filtering for "${prefixToFilter}" was cancelled.`);if(!isLoading){cleanupUIState();if(speedDialContainerEl)speedDialContainerEl.style.display='flex';if(controlsContainerEl)controlsContainerEl.style.display='none';if(document.body)document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Filtragem por "${prefixToFilter}" cancelada.`,!1);endOperation(!1)}}if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(document.body&&!document.body.classList.contains('cover-active')){document.body.classList.remove('cover-active')}}}
     
-    async function displayGlobalMediaByPrefix(t){if(!t||isLoading||!allSelectedFiles)return;if(searchInputEl&&searchInputEl.value)searchInputEl.value='';if(searchSuggestionsEl){searchSuggestionsEl.innerHTML='';searchSuggestionsEl.style.display='none'}const s=beginOperation();let g=null;let coverItemName = null; try{
+    async function displayGlobalMediaByPrefix(prefixToSearch){if(!prefixToSearch||isLoading||!allSelectedFiles)return;if(searchInputEl&&searchInputEl.value)searchInputEl.value='';if(searchSuggestionsEl){searchSuggestionsEl.innerHTML='';searchSuggestionsEl.style.display='none'}const signal=beginOperation();let coverBlobUrl=null;let coverItemName = null; try{
         updateMainHeader('Random Media'); // Reset header
         resetLuckyFeature(); if(speedDialContainerEl) speedDialContainerEl.style.display = 'none';
-        clearTimeout(window.coverDisplayTimeoutId||0);if(coverOverlayBlur){coverOverlayBlur.classList.remove('visible');coverOverlayBlur.style.backgroundImage='none'}if(coverOverlay){coverOverlay.classList.remove('visible');coverOverlay.style.backgroundImage='none'}if(document.body)document.body.classList.remove('cover-active');if(loadingIndicatorEl){loadingIndicatorEl.textContent=`Pesquisando por "${t}" em todos os Caminhos...`;loadingIndicatorEl.style.display='block'}if(s.aborted)throw new DOMException('Cancelled early (global search)','AbortError');const o=[],r=[];const a=t.toLowerCase();const b=rootDirName?`${rootDirName}/${CAPAS_FOLDER_NAME}/`:`${CAPAS_FOLDER_NAME}/`;for(const f of allSelectedFiles){if(s.aborted)throw new DOMException('Scan Cancelled during file iteration (global search)','AbortError');const l=f.webkitRelativePath?.replace(/^\.\//,'');if(!l||!isMediaFile(f.name))continue;const p=l.split('/');if(p.length<(rootDirName?2:1))continue;const n=p[p.length-1],h=getFirstTwoWords(n);if(h.toLowerCase()!==a)continue;const k=p.slice(0,-1),S=k.join('/')+(k.length>0?'/':'');let C=!1,R=!1,O=!1;if(S===b){C=!0}else{for(const x of CAMINHO_FOLDER_NAMES){const N=rootDirName?`${rootDirName}/${x}/`:`${x}/`;if(S.startsWith(N)){R=!0;O=k.some(e=>e.toLowerCase()===ORIGINAIS_FOLDER_NAME);break}}}if(C||R){const M={name:n,fileRef:f,relativePath:l,isCoverFile:C,isOriginal:O,prefix:h,blobUrl:null,type:null,loadSuccess:null,abortController:null};if(C){o.push(M)}else if(R){r.push(M)}}}if(r.length===0&&o.length===0){console.warn(`Prefix "${t}" not found anywhere.`);if(mediaContainerEl)mediaContainerEl.style.display='none';if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Prefixo "${t}" não encontrado em nenhum Caminho. Tente outro.`,!1);endOperation(!0);return}let F=r;if(F.length>MAX_FILTERED_ITEMS){F=getRandomMedia(F,MAX_FILTERED_ITEMS)}if(F.length===0){console.warn(`No regular media found globally for prefix "${t}", only covers or empty regulars list.`);if(coverOverlayBlur){coverOverlayBlur.classList.remove('visible');coverOverlayBlur.style.backgroundImage='none'}if(coverOverlay){coverOverlay.classList.remove('visible');coverOverlay.style.backgroundImage='none'}if(document.body)document.body.classList.remove('cover-active');if(mediaContainerEl){mediaContainerEl.innerHTML='';mediaContainerEl.style.display='none'}if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Nenhum item regular encontrado para "${t}" em todos os Caminhos. Selecione outro.`,!1);endOperation(!0);return}if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(mediaContainerEl)mediaContainerEl.style.display='block';if(controlsContainerEl)controlsContainerEl.style.display='flex';document.body.classList.remove('initial-load');if(o.length>0){const u=o.filter(i=>i.loadSuccess!==!1);if(u.length>0){const m=u[Math.floor(Math.random()*u.length)];g=await loadCoverImageBlobUrl(m,s); coverItemName = m.name;}}
+        clearTimeout(window.coverDisplayTimeoutId||0);if(coverOverlayBlur){coverOverlayBlur.classList.remove('visible');coverOverlayBlur.style.backgroundImage='none'}if(coverOverlay){coverOverlay.classList.remove('visible');coverOverlay.style.backgroundImage='none'}if(document.body)document.body.classList.remove('cover-active');if(loadingIndicatorEl){loadingIndicatorEl.textContent=`Pesquisando por "${prefixToSearch}" em todos os Caminhos...`;loadingIndicatorEl.style.display='block'}if(signal.aborted)throw new DOMException('Cancelled early (global search)','AbortError');
+        
+        const mediaGroupData = mediaIndex.get(prefixToSearch.toLowerCase());
+
+        if (!mediaGroupData || (!mediaGroupData.regulars?.length && !mediaGroupData.covers?.length)) {
+            console.warn(`Prefix "${prefixToSearch}" not found in mediaIndex or has no files.`);
+            if(mediaContainerEl)mediaContainerEl.style.display='none';
+            if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';
+            if(controlsContainerEl)controlsContainerEl.style.display='none';
+            if(speedDialContainerEl)speedDialContainerEl.style.display='flex';
+            document.body.classList.add('initial-load');
+            activateLuckyFeature();
+            setSpeedDialStatus(`Prefixo "${prefixToSearch}" não encontrado ou sem mídias associadas.`,false);
+            endOperation(true);
+            return;
+        }
+
+        const coverItemsMetaGlobal = mediaGroupData.covers || [];
+        let regularItemsMetaGlobal = mediaGroupData.regulars || [];
+        
+        let finalRegularItemsMeta=regularItemsMetaGlobal;
+        if(finalRegularItemsMeta.length>MAX_FILTERED_ITEMS){finalRegularItemsMeta=getRandomMedia(finalRegularItemsMeta,MAX_FILTERED_ITEMS)}
+        
+        // This condition now checks if, after potentially sampling, there are no regular items to display.
+        // It's possible a prefix exists in mediaIndex but only has covers, or its regular items were filtered out by getRandomMedia.
+        if(finalRegularItemsMeta.length===0){
+            console.warn(`No regular media items to display for prefix "${prefixToSearch}" after filtering/sampling.`);
+            // If there are covers, they might still be shown. If not, then it's effectively "not found".
+            if (coverItemsMetaGlobal.length === 0) {
+                if(mediaContainerEl)mediaContainerEl.style.display='none';
+                if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';
+                if(controlsContainerEl)controlsContainerEl.style.display='none';
+                if(speedDialContainerEl)speedDialContainerEl.style.display='flex';
+                document.body.classList.add('initial-load');
+                activateLuckyFeature();
+                setSpeedDialStatus(`Nenhum item regular encontrado para "${prefixToSearch}".`,false);
+                endOperation(true);
+                return;
+            }
+            // If there are covers but no regulars, the cover will be shown, and displayMedia will handle empty regulars.
+        }
+        
+        if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(mediaContainerEl)mediaContainerEl.style.display='block';if(controlsContainerEl)controlsContainerEl.style.display='flex';document.body.classList.remove('initial-load');
+        
+        if(coverItemsMetaGlobal.length>0){
+            const validCoversMeta = coverItemsMetaGlobal.filter(i=>i.loadSuccess!==false); // loadSuccess is on itemMeta
+            if(validCoversMeta.length>0){
+                const selectedCoverMeta = validCoversMeta[Math.floor(Math.random()*validCoversMeta.length)];
+                coverBlobUrl=await loadCoverImageBlobUrl(selectedCoverMeta,signal); // Pass metadata
+                coverItemName = selectedCoverMeta.name;
+            }
+        }
         
         if (coverItemName) { // Update header if cover is shown
             const username = getInstagramUsername(coverItemName);
             if (username) updateMainHeader('@' + username);
         }
 
-        if(s.aborted)throw new DOMException('Cancelled during global cover load','AbortError');if(g){if(coverOverlayBlur){coverOverlayBlur.style.backgroundImage=`url('${g}')`;requestAnimationFrame(()=>{if(!s.aborted)coverOverlayBlur.classList.add('visible')})}if(coverOverlay){coverOverlay.style.backgroundImage=`url('${g}')`;requestAnimationFrame(()=>{if(!s.aborted)coverOverlay.classList.add('visible')})}if(document.body&&!s.aborted)document.body.classList.add('cover-active');window.coverDisplayTimeoutId=setTimeout(async()=>{if(s.aborted)return;try{await displayMedia(F,s,!1);endOperation(!0)}catch(d){if(d.name!=='AbortError'){console.error("Error during post-cover global media display:",d);setSpeedDialStatus(`Erro ao exibir mídia global para "${t}" após a capa.`,!0)}endOperation(!1)}},COVER_DISPLAY_DELAY)}else{await displayMedia(F,s,!1);endOperation(!0)}}catch(e){if(e.name!=='AbortError'){console.error(`Error global filtering for prefix "${t}":`,e);if(mediaContainerEl)mediaContainerEl.style.display='none';if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Erro ao filtrar globalmente por "${t}". Verifique o console.`,!0);endOperation(!1)}else{console.log(`Global filtering for "${t}" was cancelled.`);if(!isLoading){cleanupUIState();if(speedDialContainerEl)speedDialContainerEl.style.display='flex';if(controlsContainerEl)controlsContainerEl.style.display='none';if(document.body)document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Filtragem global por "${t}" cancelada.`,!1);endOperation(!1)}}if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(document.body&&!document.body.classList.contains('cover-active')){document.body.classList.remove('cover-active')}}}
+        if(signal.aborted)throw new DOMException('Cancelled during global cover load','AbortError');if(coverBlobUrl){if(coverOverlayBlur){coverOverlayBlur.style.backgroundImage=`url('${coverBlobUrl}')`;requestAnimationFrame(()=>{if(!signal.aborted)coverOverlayBlur.classList.add('visible')})}if(coverOverlay){coverOverlay.style.backgroundImage=`url('${coverBlobUrl}')`;requestAnimationFrame(()=>{if(!signal.aborted)coverOverlay.classList.add('visible')})}if(document.body&&!signal.aborted)document.body.classList.add('cover-active');window.coverDisplayTimeoutId=setTimeout(async()=>{if(signal.aborted)return;try{await displayMedia(finalRegularItemsMeta,signal,!1);endOperation(!0)}catch(d){if(d.name!=='AbortError'){console.error("Error during post-cover global media display:",d);setSpeedDialStatus(`Erro ao exibir mídia global para "${prefixToSearch}" após a capa.`,!0)}endOperation(!1)}},COVER_DISPLAY_DELAY)}else{await displayMedia(finalRegularItemsMeta,signal,!1);endOperation(!0)}}catch(e){if(e.name!=='AbortError'){console.error(`Error global filtering for prefix "${prefixToSearch}":`,e);if(mediaContainerEl)mediaContainerEl.style.display='none';if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Erro ao filtrar globalmente por "${prefixToSearch}". Verifique o console.`,!0);endOperation(!1)}else{console.log(`Global filtering for "${prefixToSearch}" was cancelled.`);if(!isLoading){cleanupUIState();if(speedDialContainerEl)speedDialContainerEl.style.display='flex';if(controlsContainerEl)controlsContainerEl.style.display='none';if(document.body)document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Filtragem global por "${prefixToSearch}" cancelada.`,!1);endOperation(!1)}}if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(document.body&&!document.body.classList.contains('cover-active')){document.body.classList.remove('cover-active')}}}
     function updateFullscreenTransform(){if(!fullscreenImgEl)return;fullscreenImgEl.style.transform=`translate(${imgOffsetX}px, ${imgOffsetY}px) rotate(${rotationAngle}deg) scale(${zoomScale})`}
     function showFullscreenMedia(s,t){if(!fullscreenMediaEl||!fullscreenImgEl||!fullscreenVideoEl||!rotateButtonEl)return;rotationAngle=0;zoomScale=1;imgOffsetX=0;imgOffsetY=0;isDragging=!1;fullscreenVideoEl.pause();fullscreenVideoEl.removeAttribute('src');if(fullscreenVideoEl.readyState>0){try{fullscreenVideoEl.load()}catch(e){}}fullscreenImgEl.removeAttribute('src');fullscreenImgEl.style.display='none';fullscreenVideoEl.style.display='none';fullscreenImgEl.removeEventListener('wheel',handleWheelZoom);fullscreenImgEl.removeEventListener('mousedown',handleMouseDownDrag);document.removeEventListener('mousemove',handleMouseMoveDrag);document.removeEventListener('mouseup',handleMouseUpDrag);fullscreenImgEl.onload=null;fullscreenImgEl.onerror=null;if(t?.startsWith('image')){fullscreenImgEl.style.display='block';rotateButtonEl.style.display='block';updateFullscreenTransform();fullscreenImgEl.onload=()=>{const c=fullscreenMediaEl.clientWidth*.9,h=fullscreenMediaEl.clientHeight*.9,i=fullscreenImgEl.naturalWidth/fullscreenImgEl.naturalHeight,r=c/h;let l;if(i>r){l=c/fullscreenImgEl.naturalWidth}else{l=h/fullscreenImgEl.naturalHeight}zoomScale=Math.min(l,1);fullscreenImgEl.style.width=`${fullscreenImgEl.naturalWidth*zoomScale}px`;fullscreenImgEl.style.height=`${fullscreenImgEl.naturalHeight*zoomScale}px`;imgOffsetX=0;imgOffsetY=0;updateFullscreenTransform();fullscreenImgEl.style.width='auto';fullscreenImgEl.style.height='auto';fullscreenImgEl.onload=null};fullscreenImgEl.onerror=()=>{console.error("Falha ao carregar imagem em tela cheia:",s);closeFullscreenMedia();fullscreenImgEl.onload=null;fullscreenImgEl.onerror=null};fullscreenImgEl.src=s;fullscreenImgEl.addEventListener('wheel',handleWheelZoom,{passive:!1});fullscreenImgEl.addEventListener('mousedown',handleMouseDownDrag)}else if(t?.startsWith('video')){fullscreenVideoEl.src=s;fullscreenVideoEl.style.display='block';rotateButtonEl.style.display='none';fullscreenVideoEl.play().catch(e=>console.warn("Autoplay bloqueado:",e))}else{console.warn("Tipo de mídia não suportado para fullscreen:",t);return}fullscreenMediaEl.style.display='flex'}
     function handleWheelZoom(e){e.preventDefault();e.stopPropagation();if(!fullscreenImgEl||fullscreenImgEl.style.display==='none')return;const r=fullscreenImgEl.getBoundingClientRect();if(r.width===0||r.height===0)return;const d=e.deltaY,s=d<0?ZOOM_SENSITIVITY:1/ZOOM_SENSITIVITY,o=zoomScale;let n=o*s;n=Math.max(MIN_ZOOM,Math.min(n,MAX_ZOOM));if(n===o)return;const m=e.clientX,y=e.clientY,cX=r.left+r.width/2,cY=r.top+r.height/2,pX_B=m-cX,pY_B=y-cY,pX_A=pX_B*(n/o),pY_A=pY_B*(n/o),dX=pX_B-pX_A,dY=pY_B-pY_A;imgOffsetX+=dX;imgOffsetY+=dY;zoomScale=n;requestAnimationFrame(updateFullscreenTransform)}
@@ -317,9 +589,114 @@
     }
 
 
-    async function processAndDisplayFilesForPath(f,t){if(!f){setSpeedDialStatus("Erro interno: Lista de arquivos não disponível.",!0);return}const s=beginOperation();resetLuckyFeature();try{
-        updateMainHeader('Random Media'); // Reset header
-        if(speedDialContainerEl)speedDialContainerEl.style.display='none';document.body.classList.remove('initial-load');cleanupUIState();mediaFiles.forEach(revokeItemResources);mediaFiles=[];mediaIndex.clear();initialViewHistory=[];sessionViewedPrefixes.clear();if(loadingIndicatorEl){loadingIndicatorEl.textContent=`Processando "${t}"...`;loadingIndicatorEl.style.display='block'}const pP=rootDirName?`${rootDirName}/${t}/`:`${t}/`,cP=rootDirName?`${rootDirName}/${CAPAS_FOLDER_NAME}/`:`${CAPAS_FOLDER_NAME}/`;let c=0;for(const i of f){if(s.aborted)throw new DOMException('Scan Cancelled during file iteration','AbortError');if(c++%100===0&&loadingIndicatorEl&&isLoading){loadingIndicatorEl.textContent=`Processando arquivos para "${t}"... (${c}/${f.length})`;await delay(1,s)}const r=i.webkitRelativePath?.replace(/^\.\//,'');if(!r||!isMediaFile(i.name))continue;const h=r.split('/');if(h.length<2)continue;const n=h[h.length-1],k=h.slice(0,-1),d=k.join('/')+'/',I=d===cP||r.startsWith(cP);let R=d.startsWith(pP)||r.startsWith(pP),O=!1;if(R){O=k.some(g=>g.toLowerCase()===ORIGINAIS_FOLDER_NAME)}if(I||R){const P=getFirstTwoWords(n);mediaFiles.push({name:n,fileRef:i,relativePath:r,isCoverFile:I,isOriginal:O,prefix:P,blobUrl:null,type:null,loadSuccess:null,abortController:null})}}if(s.aborted)throw new DOMException('Processing Operation Cancelled after file iteration','AbortError');if(mediaFiles.length>0){if(loadingIndicatorEl)loadingIndicatorEl.textContent=`Indexando ${mediaFiles.length} itens...`;buildMediaIndex(s);if(s.aborted)throw new DOMException('Indexing Cancelled','AbortError');const N=mediaFiles.filter(i=>!i.isCoverFile);if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(N.length>0){if(controlsContainerEl)controlsContainerEl.style.display='flex';await displayMedia(getRandomInitialMedia(N,MAX_INITIAL_ITEMS),s,!0);
+    async function processAndDisplayFilesForPath(files, targetCaminhoName) { // files is allSelectedFiles, targetCaminhoName is like "Caminho 1"
+        if (!files) { // Should be allSelectedFiles from main thread
+            setSpeedDialStatus("Erro interno: Lista de arquivos não disponível.", true);
+            return;
+        }
+        const signal = beginOperation();
+        resetLuckyFeature();
+        try {
+            updateMainHeader('Random Media');
+            if (speedDialContainerEl) speedDialContainerEl.style.display = 'none';
+            document.body.classList.remove('initial-load');
+            cleanupUIState();
+            
+            // Global mediaFiles and mediaIndex are populated by the worker.
+            // This function filters mediaFiles for the targetCaminhoName.
+            initialViewHistory = []; // Reset history for the new path context
+            sessionViewedPrefixes.clear(); // Reset session prefixes for the new path
+
+            if (loadingIndicatorEl) {
+                loadingIndicatorEl.textContent = `Filtrando mídia para "${targetCaminhoName}"...`;
+                loadingIndicatorEl.style.display = 'block';
+            }
+
+            const pathPrefixToMatch = rootDirName ? `${rootDirName}/${targetCaminhoName}/` : `${targetCaminhoName}/`;
+            // Covers are global, so we don't filter them by pathPrefixToMatch unless they are also in that path.
+            // The displayFilteredMedia function (which this is similar to) handles cover logic.
+            // For now, let's focus on regular items within this path.
+            const filesForThisPathMeta = mediaFiles.filter(fileMeta => {
+                if (signal.aborted) throw new DOMException('Filtering cancelled during path match', 'AbortError');
+                return fileMeta.relativePath.startsWith(pathPrefixToMatch);
+            });
+
+            if (signal.aborted) throw new DOMException('Processing Operation Cancelled after filtering mediaFiles', 'AbortError');
+
+            if (filesForThisPathMeta.length > 0) {
+                const regularItemsInPathMeta = filesForThisPathMeta.filter(i => !i.isCoverFile);
+
+                if (loadingIndicatorEl) loadingIndicatorEl.style.display = 'none';
+
+                if (regularItemsInPathMeta.length > 0) {
+                    if (controlsContainerEl) controlsContainerEl.style.display = 'flex';
+                    // getRandomInitialMedia expects metadata array
+                    await displayMedia(getRandomInitialMedia(regularItemsInPathMeta, MAX_INITIAL_ITEMS), signal, true); 
+                    
+                    const uniquePrefixesInPath = Array.from(new Set(regularItemsInPathMeta.map(fileMeta => fileMeta.prefix).filter(Boolean))).sort((a, b) => a.localeCompare(b));
+                    showCaminhoSidebar(targetCaminhoName, uniquePrefixesInPath);
+                } else {
+                    if(mediaContainerEl)mediaContainerEl.style.display='none';
+                    if(controlsContainerEl)controlsContainerEl.style.display='none';
+                    if(speedDialContainerEl)speedDialContainerEl.style.display='flex';
+                    document.body.classList.add('initial-load');
+                    activateLuckyFeature();
+                    setSpeedDialStatus(`"${targetCaminhoName}" não contém arquivos de mídia regulares. Selecione outro.`, false);
+                    hideCaminhoSidebar();
+                    endOperation(true);
+                    return;
+                }
+            } else {
+                if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';
+                if(mediaContainerEl)mediaContainerEl.style.display='none';
+                if(controlsContainerEl)controlsContainerEl.style.display='none';
+                if(speedDialContainerEl)speedDialContainerEl.style.display='flex';
+                document.body.classList.add('initial-load');
+                activateLuckyFeature();
+                setSpeedDialStatus(`Nenhum arquivo de mídia relevante encontrado para "${targetCaminhoName}".`, true);
+                hideCaminhoSidebar();
+                endOperation(true);
+                return;
+            }
+            endOperation(true);
+        } catch (e) {
+            if (e.name !== 'AbortError') {
+                console.error(`Error processing path "${targetCaminhoName}":`, e);
+            }
+            cleanupUIState();
+            if(mediaContainerEl)mediaContainerEl.style.display='none';
+            if(controlsContainerEl)controlsContainerEl.style.display='none';
+            if(speedDialContainerEl)speedDialContainerEl.style.display='flex';
+            document.body.classList.add('initial-load');
+            if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';
+            const m=e.name==='AbortError'?`Operação cancelada ao processar "${targetCaminhoName}".`:`Erro ao processar "${targetCaminhoName}": ${e.message||'Erro desconhecido'}.`;
+            activateLuckyFeature();
+            setSpeedDialStatus(m,e.name!=='AbortError');
+            // resetSpeedDialIcons(); // These use allSelectedFiles, should be fine
+            // resetFavicon(); // Uses allSelectedFiles
+            hideCaminhoSidebar();
+            endOperation(false);
+        }
+    }
+
+    function handleSearchInput(){if(!searchInputEl||!searchSuggestionsEl||!mediaIndex)return;const t=searchInputEl.value.trim().toLowerCase();searchSuggestionsEl.innerHTML='';if(t.length===0){searchSuggestionsEl.style.display='none';return}const n=new Map();
+        // mediaIndex is now global and from the worker
+        for(const e of mediaIndex.keys()){ // e is prefix string (e.g. "Movie Name")
+            if(e.startsWith(t)&&!/^icon(\s*\d*)?$/i.test(e)){ // Make sure it's not an icon prefix
+                const i=mediaIndex.get(e); // i is {covers: [coverMeta,...], regulars: [regularMeta,...]}
+                if(i&&i.covers&&i.covers.length>0){
+                    const o=i.covers[0]; // o is a cover file metadata object from worker
+                    if(o&&o.prefix){ // Ensure prefix exists on the cover metadata
+                        if(!n.has(o.prefix)){ // Use the prefix from the cover metadata as the key
+                            n.set(o.prefix,o); // Store the cover metadata object itself
+                            if(n.size>=MAX_SEARCH_SUGGESTIONS)break
+                        }
+                    }
+                }
+            }
+        }
+        if(n.size>0){const s=Array.from(n.keys()).sort((a,b)=>a.localeCompare(b)),c=document.createDocumentFragment();for(const e of s){const i=n.get(e),o=document.createElement('div');o.className='suggestion-item';o.title=`Mostrar mídia para "${e}"`;o.setAttribute('role','option');o.tabIndex=-1;const l=document.createElement('img');l.className='suggestion-thumbnail';l.alt=`Capa para ${e}`;o.appendChild(l);(async()=>{try{if(i){if(!i.blobUrl||i.loadSuccess!==true){await loadBlobForItem(i,null)}if(i.blobUrl&&i.loadSuccess===true){l.src=i.blobUrl;l.onload=()=>l.classList.add('loaded');l.onerror=()=>{l.style.display='none';console.warn(`Error rendering suggestion thumbnail for ${e}`)}}else{l.style.display='none'}}else{l.style.display='none'}}catch(a){console.warn(`Error in async load for suggestion thumbnail ${e}:`,a);l.style.display='none'}})();const r=document.createElement('span');r.className='suggestion-text';r.textContent=e;o.appendChild(r);o.addEventListener('mousedown',a=>{a.preventDefault();handleSuggestionClick(e)});o.addEventListener('keydown',a=>{if(a.key==='Enter')handleSuggestionClick(e)});c.appendChild(o)}searchSuggestionsEl.appendChild(c);searchSuggestionsEl.style.display='block'}else{searchSuggestionsEl.style.display='none'}
+    }
             const uniquePrefixesInPath = Array.from(new Set(N.map(file => file.prefix).filter(Boolean))).sort((a,b) => a.localeCompare(b));
             showCaminhoSidebar(t, uniquePrefixesInPath);
         }else{if(mediaContainerEl)mediaContainerEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`"${t}" não contém arquivos de mídia regulares. Selecione outro.`,!1);hideCaminhoSidebar();endOperation(!0);return}}else{if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';if(mediaContainerEl)mediaContainerEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');activateLuckyFeature();setSpeedDialStatus(`Nenhum arquivo de mídia relevante encontrado para "${t}". Selecione outro.`,!0);hideCaminhoSidebar();endOperation(!0);return}endOperation(!0)}catch(e){if(e.name!=='AbortError'){console.error(`Error processing path "${t}":`,e)}cleanupUIState();if(mediaContainerEl)mediaContainerEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');if(loadingIndicatorEl)loadingIndicatorEl.style.display='none';const m=e.name==='AbortError'?`Operação cancelada ao processar "${t}".`:`Erro ao processar "${t}": ${e.message||'Erro desconhecido'}.`;activateLuckyFeature();setSpeedDialStatus(m,e.name!=='AbortError');resetSpeedDialIcons();resetFavicon();hideCaminhoSidebar();endOperation(!1)}}
@@ -330,7 +707,26 @@
     function hideSuggestionsOnClickOutside(e){if(!searchInputEl||!searchSuggestionsEl)return;if(!e.target.closest('.search-container')&&!e.target.closest('#search-suggestions')){searchSuggestionsEl.innerHTML='';searchSuggestionsEl.style.display='none'}}
     function loadSpeedDialConfig(){try{const s=localStorage.getItem(SPEED_DIAL_CONFIG_KEY);if(s){const p=JSON.parse(s);if(Array.isArray(p)&&p.every(i=>i&&typeof i.originalName==='string'&&typeof i.displayName==='string')){const c=new Set(p.map(i=>i.originalName)),d=new Set(CAMINHO_FOLDER_NAMES);if(c.size===d.size&&[...c].every(n=>d.has(n))){speedDialConfig=p;return}else{console.warn("Speed dial config mismatch with defaults. Resetting.");throw new Error("Config mismatch")}}else{console.warn("Invalid speed dial config found in localStorage. Resetting.")}}}catch(e){console.error("Failed to load or parse speed dial config. Resetting to default.",e)}speedDialConfig=CAMINHO_FOLDER_NAMES.map(n=>({originalName:n,displayName:n}));saveSpeedDialConfig()}
     function saveSpeedDialConfig(){try{localStorage.setItem(SPEED_DIAL_CONFIG_KEY,JSON.stringify(speedDialConfig))}catch(e){console.error("Failed to save speed dial config to localStorage:",e);setSpeedDialStatus("Não foi possível salvar a ordem/nomes dos itens.",!0)}}
-    async function handleCaminhoSelection(e){const t=e.target.closest('.speed-dial-item');if(isLoading||!allSelectedFiles||!t){if(!allSelectedFiles&&!isLoading)setSpeedDialStatus("Selecione a pasta 'Nucleo' primeiro.",!0);return}const o=t.dataset.caminho;if(!o){console.error("Clicked speed dial item missing 'data-caminho' attribute.",t);setSpeedDialStatus("Erro ao identificar o caminho selecionado.",!0);return}resetLuckyFeature(); await processAndDisplayFilesForPath(allSelectedFiles,o)}
+    async function handleCaminhoSelection(event){ 
+        const targetElement=event.target.closest('.speed-dial-item');
+        // Ensure allSelectedFiles (the FileList) is present, as processAndDisplayFilesForPath might trigger blob loading.
+        // And ensure mediaFiles (metadata from worker) is present, as processAndDisplayFilesForPath filters it.
+        if(isLoading||!allSelectedFiles||mediaFiles.length === 0||!targetElement){ 
+            if(!allSelectedFiles && !isLoading) setSpeedDialStatus("Selecione a pasta 'Nucleo' primeiro.",true);
+            else if (mediaFiles.length === 0 && !isLoading) setSpeedDialStatus("Aguarde o processamento dos arquivos terminar.", true);
+            return;
+        }
+        const caminhoName=targetElement.dataset.caminho;
+        if(!caminhoName){
+            console.error("Clicked speed dial item missing 'data-caminho' attribute.",targetElement);
+            setSpeedDialStatus("Erro ao identificar o caminho selecionado.",true);
+            return;
+        }
+        resetLuckyFeature(); 
+        // Pass allSelectedFiles (main thread FileList) for potential blob loading,
+        // and caminhoName for filtering the global mediaFiles (worker metadata).
+        await processAndDisplayFilesForPath(allSelectedFiles,caminhoName);
+    }
     function renderSpeedDialItems(){if(!speedDialOptionsEl)return;speedDialOptionsEl.innerHTML='';const f=document.createDocumentFragment();speedDialConfig.forEach(c=>{const i=document.createElement('div');i.className='speed-dial-item';i.dataset.caminho=c.originalName;i.setAttribute('role','button');i.setAttribute('tabindex','0');i.draggable=!0;const o=document.createElement('div');o.className='icon-container';const m=document.createElement('img');m.className='speed-dial-icon';m.alt=`Ícone para ${c.displayName}`;m.src="";m.loading='lazy';const u=iconBlobUrls.get(c.originalName);if(u){m.src=u;m.classList.add('loaded')}else{i.classList.remove('icon-error')}o.appendChild(m);i.appendChild(o);const textEl=document.createElement('span');textEl.className='text';textEl.textContent=c.displayName;i.appendChild(textEl);const e=document.createElement('button');e.className='edit-btn';e.innerHTML='✎';e.title=`Renomear ${c.displayName}`;e.setAttribute('aria-label',`Renomear ${c.displayName}`);e.onclick=b=>{b.stopPropagation();b.preventDefault();handleRenameItem(c.originalName)};i.appendChild(e);i.addEventListener('click',handleCaminhoSelection);i.addEventListener('keydown',b=>{if(b.key==='Enter'||b.key===' '){b.preventDefault();handleCaminhoSelection(b)}});i.addEventListener('dragstart',handleDragStart);i.addEventListener('dragover',handleDragOver);i.addEventListener('dragleave',handleDragLeave);i.addEventListener('drop',handleDrop);i.addEventListener('dragend',handleDragEnd);f.appendChild(i)});speedDialOptionsEl.appendChild(f)}
     function handleRenameItem(o){const i=speedDialConfig.findIndex(t=>t.originalName===o);if(i===-1)return;const c=speedDialConfig[i].displayName,n=prompt(`Digite o novo nome para "${c}" (original: ${o}):`,c);if(n&&n.trim()!==''&&n.trim()!==c){speedDialConfig[i].displayName=n.trim();saveSpeedDialConfig();renderSpeedDialItems();setSpeedDialStatus(`"${c}" renomeado para "${n}".`,!1)}else if(n===null){setSpeedDialStatus("Renomeação cancelada.",!1)}else{setSpeedDialStatus("Nome inválido ou inalterado.",!0)}}
     function handleDragStart(e){const i=e.target.closest('.speed-dial-item');if(!i)return;draggedItemOriginalName=i.dataset.caminho;e.dataTransfer.setData('text/plain',draggedItemOriginalName);e.dataTransfer.effectAllowed='move';setTimeout(()=>i.classList.add('dragging'),0)}
@@ -338,46 +734,318 @@
     function handleDragLeave(e){const t=e.target.closest('.speed-dial-item');if(t){t.classList.remove('drag-over')}}
     function handleDrop(e){e.preventDefault();const t=e.target.closest('.speed-dial-item');if(!t||t.dataset.caminho===draggedItemOriginalName||!draggedItemOriginalName){if(t)t.classList.remove('drag-over');return}const o=t.dataset.caminho;t.classList.remove('drag-over');const d=speedDialConfig.findIndex(i=>i.originalName===draggedItemOriginalName),g=speedDialConfig.findIndex(i=>i.originalName===o);if(d!==-1&&g!==-1){const[r]=speedDialConfig.splice(d,1);speedDialConfig.splice(g,0,r);saveSpeedDialConfig();renderSpeedDialItems();setSpeedDialStatus("Ordem atualizada.",!1)}draggedItemOriginalName=null}
     function handleDragEnd(e){const i=e.target.closest('.speed-dial-item');if(i){i.classList.remove('dragging')}document.querySelectorAll('.speed-dial-item.drag-over').forEach(el=>el.classList.remove('drag-over'));draggedItemOriginalName=null}
-    async function handleFolderSelection(e){if(isLoading)return;const f=e.target.files,i=e.target;if(!f||f.length===0){setSpeedDialStatus("Nenhuma pasta selecionada ou seleção cancelada.",!1);allSelectedFiles=null;rootDirName='';if(selectNucleoButtonEl)selectNucleoButtonEl.style.display='inline-block';if(speedDialOptionsEl)speedDialOptionsEl.style.display='none';resetSpeedDialIcons();resetFavicon();resetLuckyFeature();document.body.classList.add('initial-load');if(controlsContainerEl) controlsContainerEl.style.display = 'none';i.value=null;hideCaminhoSidebar(); updateMainHeader('Random Media'); return}let r="Seleção",p=!0;if(f[0]?.webkitRelativePath){const F=f[0].webkitRelativePath.replace(/^\.\//,''),s=F.split('/')[0];if(s){r=s;for(let t=1;t<f.length;t++){const l=f[t].webkitRelativePath?.replace(/^\.\//,'');if(!l||!l.startsWith(r+'/')){p=!1;r="Seleção";console.warn("Inconsistent paths detected. Not a single root folder selection.");break}}}}else{p=!1}allSelectedFiles=f;rootDirName=r;initialViewHistory=[];sessionViewedPrefixes.clear();mediaFiles.forEach(revokeItemResources);mediaFiles=[];mediaIndex.clear();cleanupUIState();resetSpeedDialIcons();resetFavicon();resetLuckyFeature(); updateMainHeader('Random Media'); if(controlsContainerEl)controlsContainerEl.style.display='none';if(selectNucleoButtonEl)selectNucleoButtonEl.style.display='none';if(document.getElementById('speed-dial-subtitle'))document.getElementById('speed-dial-subtitle').style.display='none';if(speedDialOptionsEl)speedDialOptionsEl.style.display='grid';setSpeedDialStatus(`Pasta "${rootDirName}" carregada (${f.length} arquivos). Carregando recursos...`);document.body.classList.add('initial-load');if(speedDialOptionsEl){speedDialOptionsEl.querySelectorAll('.speed-dial-item').forEach(t=>{t.style.pointerEvents='auto';t.removeAttribute('aria-disabled')})}i.value=null;renderSpeedDialItems();await loadSpecificIcons(allSelectedFiles);await loadSpecificFavicon(allSelectedFiles);activateLuckyFeature();hideCaminhoSidebar();}
+    async function handleFolderSelection(e){
+        if(isLoading)return;
+        const filesFromFileList = e.target.files; // Standard FileList from input
+        const inputElement = e.target;
+
+        if(!filesFromFileList||filesFromFileList.length===0){
+            setSpeedDialStatus("Nenhuma pasta selecionada ou seleção cancelada.",false);
+            allSelectedFiles=null;rootDirName='';
+            if(selectNucleoButtonEl)selectNucleoButtonEl.style.display='inline-block';
+            if(speedDialOptionsEl)speedDialOptionsEl.style.display='none';
+            resetSpeedDialIcons();resetFavicon();resetLuckyFeature();
+            document.body.classList.add('initial-load');
+            if(controlsContainerEl) controlsContainerEl.style.display = 'none';
+            inputElement.value=null; // Reset file input
+            hideCaminhoSidebar(); 
+            updateMainHeader('Random Media'); 
+            return;
+        }
+
+        // Abort previous operation and terminate worker if running
+        if (currentOperationController) {
+            currentOperationController.abort(); // This signal should also be passed to worker
+            console.log("Main: Aborting previous operation due to new folder selection.");
+        }
+        if (worker) { // Terminate existing worker
+            console.log("Main: Terminating existing worker for new folder selection.");
+            worker.terminate();
+        }
+        
+        const signal = beginOperation(); // Gets a new AbortController's signal
+        initializeWorker(signal); // Initialize new worker and pass the signal to it
+
+        let currentRootDirName="Seleção";
+        // Root directory name detection logic (remains the same)
+        if(filesFromFileList[0]?.webkitRelativePath){
+            const firstPath=filesFromFileList[0].webkitRelativePath.replace(/^\.\//,'');
+            const firstRootDir=firstPath.split('/')[0];
+            if(firstRootDir){
+                currentRootDirName=firstRootDir;
+                for(let i=1;i<filesFromFileList.length;i++){
+                    const path=filesFromFileList[i].webkitRelativePath?.replace(/^\.\//,'');
+                    if(!path||!path.startsWith(currentRootDirName+'/')){
+                        currentRootDirName="Seleção";
+                        console.warn("Inconsistent paths detected. Not a single root folder selection.");
+                        break;
+                    }
+                }
+            }
+        }
+        
+        allSelectedFiles=filesFromFileList; // Keep FileList on main thread for blob creation
+        rootDirName=currentRootDirName;
+        
+        initialViewHistory=[];sessionViewedPrefixes.clear();
+        mediaFiles.forEach(revokeItemResources); // Revoke any existing blob URLs
+        mediaFiles=[]; mediaIndex.clear(); // These will be populated by the worker
+
+        cleanupUIState();resetSpeedDialIcons();resetFavicon();resetLuckyFeature();
+        updateMainHeader('Random Media'); 
+        if(controlsContainerEl)controlsContainerEl.style.display='none';
+        if(selectNucleoButtonEl)selectNucleoButtonEl.style.display='none';
+        if(document.getElementById('speed-dial-subtitle'))document.getElementById('speed-dial-subtitle').style.display='none';
+        if(speedDialOptionsEl)speedDialOptionsEl.style.display='grid'; // Show speed dial options
+        
+        setSpeedDialStatus(`Processando "${rootDirName}" com Web Worker (${allSelectedFiles.length} itens)...`);
+        if(loadingIndicatorEl) {
+            loadingIndicatorEl.textContent = `Initializing worker for "${rootDirName}"... (0%)`;
+            loadingIndicatorEl.style.display = 'block';
+        }
+        document.body.classList.add('initial-load');
+        if(speedDialOptionsEl){speedDialOptionsEl.querySelectorAll('.speed-dial-item').forEach(t=>{t.style.pointerEvents='auto';t.removeAttribute('aria-disabled')})}
+        
+        inputElement.value=null; // Reset file input after getting files
+        renderSpeedDialItems(); // Render speed dial structure
+
+        // Prepare data for worker (paths and names only - structured cloneable)
+        const filesDataForWorker = [];
+        for (let i = 0; i < allSelectedFiles.length; i++) {
+            if (signal.aborted) break; // Check if operation was aborted during this loop
+            filesDataForWorker.push({
+                name: allSelectedFiles[i].name,
+                webkitRelativePath: allSelectedFiles[i].webkitRelativePath,
+            });
+        }
+
+        if (signal.aborted) { // Check if aborted before posting to worker
+            console.log("Main: Folder selection aborted before sending to worker.");
+            setSpeedDialStatus("Operação cancelada pelo usuário.", true);
+            if(loadingIndicatorEl) loadingIndicatorEl.style.display = 'none';
+            endOperation(false); 
+            return;
+        }
+        
+        console.log(`Main: Sending ${filesDataForWorker.length} file metadata items to worker for root: ${rootDirName}`);
+        worker.postMessage({
+            filesData: filesDataForWorker,
+            rootDirName: rootDirName,
+            // Constants are defined in worker.js, no need to pass unless they change dynamically
+            signal: signal // Pass the AbortSignal to the worker
+        });
+        // UI updates (hiding loading, enabling buttons, displaying media) will now happen in worker.onmessage
+        // loadSpecificIcons, loadSpecificFavicon, activateLuckyFeature also moved to worker.onmessage
+    }
+
     async function handleReturnToSpeedDialClick(){if(isLoading)return;const s=beginOperation();try{
-        updateMainHeader('Random Media'); // Reset header
-        cleanupUIState();if(mediaContainerEl)mediaContainerEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');setSpeedDialStatus("Selecione um Caminho ou carregue uma nova pasta 'Nucleo'.",!1);mediaFiles.forEach(revokeItemResources);mediaFiles=[];mediaIndex.clear();initialViewHistory=[];sessionViewedPrefixes.clear();hideCaminhoSidebar();endOperation(!0);activateLuckyFeature();}catch(e){if(e.name!=='AbortError'){console.error("Error returning to speed dial:",e);setSpeedDialStatus("Erro ao retornar ao início. Verifique o console.",!0)}endOperation(!1); return;}
+        updateMainHeader('Random Media'); 
+        cleanupUIState();if(mediaContainerEl)mediaContainerEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(speedDialContainerEl)speedDialContainerEl.style.display='flex';document.body.classList.add('initial-load');setSpeedDialStatus("Selecione um Caminho ou carregue uma nova pasta 'Nucleo'.",false);
+        
+        // Global mediaFiles & mediaIndex (from worker) can be kept as they represent the last loaded folder.
+        // Or, if a full reset to "no folder loaded" state is desired:
+        // mediaFiles.forEach(revokeItemResources); mediaFiles=[]; mediaIndex.clear();
+        
+        initialViewHistory=[];sessionViewedPrefixes.clear();
+        hideCaminhoSidebar();endOperation(true);activateLuckyFeature();}catch(e){if(e.name!=='AbortError'){console.error("Error returning to speed dial:",e);setSpeedDialStatus("Erro ao retornar ao início. Verifique o console.",true)}endOperation(false); return;}
     }
     function handleGlobalKeyDown(e){if(e.key==='Escape'){if(fullscreenMediaEl&&fullscreenMediaEl.style.display==='flex'){closeFullscreenMedia()} else if (caminhoSidebarEl && caminhoSidebarEl.classList.contains('visible')) {hideCaminhoSidebar();}}}
-    document.addEventListener('DOMContentLoaded',()=>{coverOverlayBlur=document.getElementById('cover-overlay-blur');coverOverlay=document.getElementById('cover-overlay');mediaContainerEl=document.getElementById('media-container');loadingIndicatorEl=document.getElementById('loading-indicator');newMediaButton=document.getElementById('new-media');themeToggleButton=document.getElementById('theme-toggle-button');speedDialContainerEl=document.getElementById('speed-dial-container');selectNucleoButtonEl=document.getElementById('select-nucleo-folder');speedDialOptionsEl=document.getElementById('speed-dial-options');speedDialStatusEl=document.getElementById('speed-dial-status');faviconElement=document.getElementById('favicon');folderInputEl=document.getElementById('folder-input');fullscreenMediaEl=document.getElementById('fullscreen-media');fullscreenImgEl=document.getElementById('fullscreen-img');fullscreenVideoEl=document.getElementById('fullscreen-video');rotateButtonEl=document.getElementById('rotate-button');searchInputEl=document.getElementById('search-input');searchSuggestionsEl=document.getElementById('search-suggestions');returnToSpeedDialButton=document.getElementById('return-to-speed-dial');luckyFeatureContainerEl=document.getElementById('lucky-feature-container');luckyImageWrapperEl=document.getElementById('lucky-image-wrapper');luckyImageEl=document.getElementById('lucky-image');luckyImageTextEl=document.getElementById('lucky-image-text');controlsContainerEl = document.querySelector('.controls-container');
-    mainHeaderTitleEl = document.getElementById('main-header-title'); // Initialize mainHeaderTitleEl
+    
+    function initializeWorker(signalForWorker) { // signalForWorker is from beginOperation
+        if (worker) { // Should have been terminated by caller if an old one existed
+            console.warn("Main: initializeWorker called but worker already exists. This might indicate an old worker wasn't terminated.");
+            worker.terminate();
+        }
+        worker = new Worker('worker.js');
+        console.log("Main: New Web Worker initialized.");
+
+        worker.onmessage = async (event) => {
+            const { type, mediaFiles: workerMediaFiles, mediaIndex: workerMediaIndexMap, message, stack, processed, total, error } = event.data;
+
+            if (signalForWorker?.aborted && type !== 'aborted') {
+                console.log("Main: Worker message received after operation was aborted on main thread. Type:", type);
+                if (type !== 'aborted') return; 
+            }
+
+            switch (type) {
+                case 'result':
+                    console.log("Main: Worker finished processing. Received mediaFiles and mediaIndex.");
+                    mediaFiles = workerMediaFiles; // Array of metadata objects from worker
+                    mediaIndex = workerMediaIndexMap; // This is now a Map directly from worker
+
+                    // These depend on allSelectedFiles and rootDirName (globals on main thread)
+                    // and the mediaIndex/mediaFiles structure from the worker.
+                    await loadSpecificIcons(allSelectedFiles); 
+                    await loadSpecificFavicon(allSelectedFiles); 
+                    activateLuckyFeature(); 
+                    
+                    if(loadingIndicatorEl) loadingIndicatorEl.style.display = 'none';
+                    setSpeedDialStatus(`Pasta "${rootDirName}" processada. ${mediaFiles.length} mídias indexadas. Escolha um "Caminho".`, false);
+                    endOperation(true); // Enable UI, operation successful from worker's perspective
+                    break;
+                case 'progress':
+                    if(loadingIndicatorEl) loadingIndicatorEl.textContent = `Worker processing "${rootDirName}"... (${total > 0 ? Math.round((processed / total) * 100) : 0}%)`;
+                    break;
+                case 'aborted':
+                    console.log("Main: Worker reported operation was aborted.");
+                    setSpeedDialStatus("Processamento cancelado via worker.", true); // Or a more neutral message
+                    if(loadingIndicatorEl) loadingIndicatorEl.style.display = 'none';
+                    endOperation(false); // Operation did not complete successfully
+                    break;
+                case 'error':
+                    console.error('Main: Error message from worker:', message, stack || (error ? error.stack : 'No stack'));
+                    setSpeedDialStatus(`Worker Error: ${message}`, true);
+                    if(loadingIndicatorEl) loadingIndicatorEl.style.display = 'none';
+                    endOperation(false);
+                    break;
+                default:
+                    console.warn("Main: Unknown message type from worker:", type, event.data);
+            }
+        };
+
+        worker.onerror = (err) => {
+            console.error('Main: Uncaught error in worker:', err.message, err);
+            setSpeedDialStatus(`Critical Worker Error: ${err.message}. Check console.`, true);
+            if(loadingIndicatorEl) loadingIndicatorEl.style.display = 'none';
+            endOperation(false);
+            // Worker is likely unusable now. It will be re-created on next folder selection.
+        };
+
+        // If a signal was passed for this worker instance, listen to its abort event
+        // to terminate the worker if the main operation is cancelled.
+        signalForWorker?.addEventListener('abort', () => {
+            console.log("Main: Abort signal triggered for current worker instance. Terminating worker.");
+            if (worker) worker.terminate(); 
+            // UI cleanup for abort is typically handled by the endOperation(false) call
+            // that would occur when the signal was originally aborted in beginOperation.
+        }, { once: true });
+    }
+
+    document.addEventListener('DOMContentLoaded',()=>{
+        // DOM element fetching remains the same
+        coverOverlayBlur=document.getElementById('cover-overlay-blur');coverOverlay=document.getElementById('cover-overlay');mediaContainerEl=document.getElementById('media-container');loadingIndicatorEl=document.getElementById('loading-indicator');newMediaButton=document.getElementById('new-media');themeToggleButton=document.getElementById('theme-toggle-button');speedDialContainerEl=document.getElementById('speed-dial-container');selectNucleoButtonEl=document.getElementById('select-nucleo-folder');speedDialOptionsEl=document.getElementById('speed-dial-options');speedDialStatusEl=document.getElementById('speed-dial-status');faviconElement=document.getElementById('favicon');folderInputEl=document.getElementById('folder-input');fullscreenMediaEl=document.getElementById('fullscreen-media');fullscreenImgEl=document.getElementById('fullscreen-img');fullscreenVideoEl=document.getElementById('fullscreen-video');rotateButtonEl=document.getElementById('rotate-button');searchInputEl=document.getElementById('search-input');searchSuggestionsEl=document.getElementById('search-suggestions');returnToSpeedDialButton=document.getElementById('return-to-speed-dial');luckyFeatureContainerEl=document.getElementById('lucky-feature-container');luckyImageWrapperEl=document.getElementById('lucky-image-wrapper');luckyImageEl=document.getElementById('lucky-image');luckyImageTextEl=document.getElementById('lucky-image-text');controlsContainerEl = document.querySelector('.controls-container');
+    mainHeaderTitleEl = document.getElementById('main-header-title'); 
     caminhoSidebarEl = document.getElementById('caminho-sidebar');
     caminhoSidebarListEl = document.getElementById('caminho-sidebar-list');
     caminhoSidebarTitleEl = document.getElementById('caminho-sidebar-title');
     caminhoSidebarCloseBtnEl = document.getElementById('caminho-sidebar-close-btn');
 
     const c={coverOverlayBlur,coverOverlay,mediaContainerEl,loadingIndicatorEl,newMediaButton,themeToggleButton,speedDialContainerEl,selectNucleoButtonEl,speedDialOptionsEl,speedDialStatusEl,faviconElement,folderInputEl,fullscreenMediaEl,fullscreenImgEl,fullscreenVideoEl,rotateButtonEl,searchInputEl,searchSuggestionsEl,returnToSpeedDialButton,luckyFeatureContainerEl,luckyImageWrapperEl,luckyImageEl,luckyImageTextEl,controlsContainerEl,caminhoSidebarEl,caminhoSidebarListEl,caminhoSidebarTitleEl,caminhoSidebarCloseBtnEl, mainHeaderTitleEl};const m=Object.entries(c).filter(([_,el])=>!el);if(m.length>0){const e=`Application Error! Required elements not found: ${m.map(([n,_])=>n).join(', ')}`;console.error(e);try{document.body.innerHTML=`<h1 style='color:red; text-align:center;'>Application Error!</h1><p style='text-align:center;'>Required elements not found: ${m.map(([n,_])=>n).join(', ')}</p>`}catch(E){}return}
-    updateMainHeader('Random Media'); // Set initial header
-    if(controlsContainerEl)controlsContainerEl.style.display='none';loadSpeedDialConfig();renderSpeedDialItems();resetLuckyFeature();function u(){themeToggleButton.textContent=document.body.classList.contains('light-theme')?'Modo Escuro':'Modo Claro'}u();themeToggleButton.addEventListener('click',()=>{document.body.classList.toggle('light-theme');const t=document.body.classList.contains('light-theme')?'light':'dark';try{localStorage.setItem(THEME_KEY,t)}catch(n){console.error("Failed to save theme preference:",n)}u()});selectNucleoButtonEl.addEventListener('click',()=>{if(isLoading)return;if(folderInputEl){folderInputEl.click();setSpeedDialStatus("Aguardando seleção da pasta 'Nucleo'...");initialViewHistory=[];sessionViewedPrefixes.clear();mediaFiles.forEach(revokeItemResources);mediaFiles=[];mediaIndex.clear();allSelectedFiles=null;rootDirName='';cleanupUIState();resetSpeedDialIcons();resetFavicon();resetLuckyFeature(); updateMainHeader('Random Media'); document.body.classList.add('initial-load');if(mediaContainerEl)mediaContainerEl.style.display='none';if(controlsContainerEl)controlsContainerEl.style.display='none';if(document.getElementById('speed-dial-subtitle'))document.getElementById('speed-dial-subtitle').style.display='block';if(speedDialOptionsEl)speedDialOptionsEl.style.display='none';renderSpeedDialItems()}});folderInputEl.addEventListener('change',handleFolderSelection);if(returnToSpeedDialButton)returnToSpeedDialButton.addEventListener('click',handleReturnToSpeedDialClick);if(luckyImageWrapperEl)luckyImageWrapperEl.addEventListener('click',handleLuckyImageClick);
+    
+    updateMainHeader('Random Media'); 
+    if(controlsContainerEl)controlsContainerEl.style.display='none';
+    loadSpeedDialConfig();renderSpeedDialItems();resetLuckyFeature();
+    
+    function u(){themeToggleButton.textContent=document.body.classList.contains('light-theme')?'Modo Escuro':'Modo Claro'}u();
+    themeToggleButton.addEventListener('click',()=>{document.body.classList.toggle('light-theme');const t=document.body.classList.contains('light-theme')?'light':'dark';try{localStorage.setItem(THEME_KEY,t)}catch(n){console.error("Failed to save theme preference:",n)}u()});
+    
+    selectNucleoButtonEl.addEventListener('click',()=>{
+        if(isLoading)return;
+        if(folderInputEl){
+            folderInputEl.click(); // This will trigger 'change' event, then handleFolderSelection
+            setSpeedDialStatus("Aguardando seleção da pasta 'Nucleo'...");
+            // Reset some state immediately, more comprehensive reset in handleFolderSelection
+            initialViewHistory=[];sessionViewedPrefixes.clear();
+            allSelectedFiles=null;rootDirName='';
+            cleanupUIState();resetSpeedDialIcons();resetFavicon();resetLuckyFeature(); 
+            updateMainHeader('Random Media'); 
+            document.body.classList.add('initial-load');
+            if(mediaContainerEl)mediaContainerEl.style.display='none';
+            if(controlsContainerEl)controlsContainerEl.style.display='none';
+            if(document.getElementById('speed-dial-subtitle'))document.getElementById('speed-dial-subtitle').style.display='block';
+            if(speedDialOptionsEl)speedDialOptionsEl.style.display='none'; // Hide until folder processed
+            renderSpeedDialItems(); // Render structure
+        }
+    });
+    
+    folderInputEl.addEventListener('change',handleFolderSelection);
+    if(returnToSpeedDialButton)returnToSpeedDialButton.addEventListener('click',handleReturnToSpeedDialClick);
+    if(luckyImageWrapperEl)luckyImageWrapperEl.addEventListener('click',handleLuckyImageClick);
     if(caminhoSidebarCloseBtnEl) caminhoSidebarCloseBtnEl.addEventListener('click', hideCaminhoSidebar);
-    newMediaButton.addEventListener('click',async()=>{if(isLoading||!allSelectedFiles||mediaFiles.length===0)return;const s=beginOperation();try{
-    updateMainHeader('Random Media'); // Reset header
-    resetLuckyFeature();if(speedDialContainerEl) speedDialContainerEl.style.display = 'none'; document.body.classList.remove('initial-load'); cleanupUIState();const n=mediaFiles.filter(i=>!i.isCoverFile);if(n.length>0){if(mediaContainerEl)mediaContainerEl.style.display='block';if(controlsContainerEl)controlsContainerEl.style.display='flex';await displayMedia(getRandomInitialMedia(n,MAX_INITIAL_ITEMS),s,!0);
-    const currentPathName = speedDialConfig.find(cfg => {
-        if (mediaFiles.length > 0 && mediaFiles[0].relativePath) {
-            const parts = mediaFiles[0].relativePath.split('/');
-            const basePath = rootDirName ? `${rootDirName}/` : '';
-            if (parts.length > (rootDirName ? 1:0) && mediaFiles[0].relativePath.startsWith(basePath)) {
-                 const caminhoPart = parts[rootDirName ? 1 : 0];
-                 return cfg.originalName === caminhoPart;
+    
+    newMediaButton.addEventListener('click',async()=>{
+        if(isLoading||!allSelectedFiles||!mediaFiles||mediaFiles.length===0) {
+            if (!allSelectedFiles && !isLoading) setSpeedDialStatus("Selecione uma pasta primeiro.", true);
+            else if ((!mediaFiles || mediaFiles.length === 0) && !isLoading) setSpeedDialStatus("Nenhum arquivo de mídia processado para exibir. Verifique a pasta ou aguarde.", true);
+            return;
+        }
+        const signal = beginOperation(); 
+        try{
+            updateMainHeader('Random Media'); 
+            resetLuckyFeature();if(speedDialContainerEl) speedDialContainerEl.style.display = 'none'; 
+            document.body.classList.remove('initial-load'); 
+            cleanupUIState();
+            
+            const regularMediaFromWorker = mediaFiles.filter(i=>!i.isCoverFile && i.relativePath.includes(rootDirName));
+            
+            if(regularMediaFromWorker.length>0){
+                if(mediaContainerEl)mediaContainerEl.style.display='block';
+                if(controlsContainerEl)controlsContainerEl.style.display='flex';
+                
+                const initialMediaToDisplay = getRandomInitialMedia(regularMediaFromWorker,MAX_INITIAL_ITEMS);
+                await displayMedia(initialMediaToDisplay,signal,true); 
+            
+                let currentPathName = "Todos os Itens"; 
+                if (initialMediaToDisplay.length > 0 && initialMediaToDisplay[0].relativePath) {
+                    const pathParts = initialMediaToDisplay[0].relativePath.split('/');
+                    // Ensure the path is within the current rootDirName context
+                    if (rootDirName && pathParts.length > 1 && pathParts[0] === rootDirName) {
+                        const possibleCaminho = pathParts[1]; // This is the "Caminho X" folder
+                        // Check if this "Caminho X" is one of the configured speed dial items
+                        if (speedDialConfig.some(cfg => cfg.originalName === possibleCaminho)) {
+                           currentPathName = possibleCaminho;
+                        }
+                    } else if (!rootDirName && pathParts.length > 0) { 
+                        // Fallback if rootDirName is not set (less likely if folder selected)
+                        const possibleCaminho = pathParts[0];
+                         if (speedDialConfig.some(cfg => cfg.originalName === possibleCaminho)) {
+                           currentPathName = possibleCaminho;
+                        }
+                    }
+                }
+                
+                let prefixesForSidebar;
+                const itemsForSidebarContext = (currentPathName !== "Todos os Itens") ? 
+                    regularMediaFromWorker.filter(file => file.relativePath.startsWith(rootDirName ? `${rootDirName}/${currentPathName}/` : `${currentPathName}/`))
+                    : regularMediaFromWorker; // If "Todos os Itens", use all regulars from the current rootDirName
+
+                prefixesForSidebar = Array.from(new Set(
+                    itemsForSidebarContext
+                        .map(file => file.prefix)
+                        .filter(Boolean)
+                )).sort((a,b) => a.localeCompare(b));
+                
+                showCaminhoSidebar(currentPathName, prefixesForSidebar);
+    
+            }else{
+                const e="text-align: center; width: 100%; column-span: all; padding: 20px 0;";
+                if(mediaContainerEl){mediaContainerEl.innerHTML=`<p style="${e}">Nada a exibir (sem mídia regular na pasta atual).</p>`;mediaContainerEl.style.display='block'} 
+                if(controlsContainerEl)controlsContainerEl.style.display='flex'; 
+                hideCaminhoSidebar();
+            }
+            endOperation(true)
+        }catch(err){ 
+            if(err.name!=='AbortError'){ 
+                console.error("Error displaying new random media:",err); 
+                const e="color:var(--error-text); text-align: center; width: 100%; column-span: all; padding: 20px 0;";
+                if(mediaContainerEl){mediaContainerEl.innerHTML=`<p style="${e}">Erro ao exibir nova mídia: ${err.message||'Erro desconhecido'}</p>`;mediaContainerEl.style.display='block'}
+                endOperation(false)
+            }else{
+                console.log("Display new media cancelled.");
+                endOperation(false)
             }
         }
-        return false;
-    })?.originalName;
-
-    if (currentPathName) {
-        const uniquePrefixesInPath = Array.from(new Set(n.map(file => file.prefix).filter(Boolean))).sort((a,b) => a.localeCompare(b));
-        showCaminhoSidebar(currentPathName, uniquePrefixesInPath);
-    } else {
-        hideCaminhoSidebar(); 
-    }
+    });
     
-    }else{const e="text-align: center; width: 100%; column-span: all; padding: 20px 0;";if(mediaContainerEl){mediaContainerEl.innerHTML=`<p style="${e}">Nada a exibir (sem mídia regular neste Caminho).</p>`;mediaContainerEl.style.display='block'} if(controlsContainerEl)controlsContainerEl.style.display='flex'; hideCaminhoSidebar();}endOperation(!0)}catch(r){if(r.name!=='AbortError'){console.error("Error displaying new random media:",r);const e="color:var(--error-text); text-align: center; width: 100%; column-span: all; padding: 20px 0;";if(mediaContainerEl){mediaContainerEl.innerHTML=`<p style="${e}">Erro ao exibir nova mídia: ${r.message||'Erro desconhecido'}</p>`;mediaContainerEl.style.display='block'}endOperation(!1)}else{console.log("Display new media cancelled.");endOperation(!1)}}});searchInputEl.addEventListener('input',handleSearchInput);searchInputEl.addEventListener('blur',e=>{setTimeout(()=>{if(!searchSuggestionsEl||!document.activeElement||!document.activeElement.closest('#search-suggestions')){if(searchSuggestionsEl){searchSuggestionsEl.innerHTML='';searchSuggestionsEl.style.display='none'}}},150)});document.addEventListener('click',hideSuggestionsOnClickOutside);searchInputEl.setAttribute('autocomplete','off');searchInputEl.disabled=!0;searchInputEl.addEventListener('keydown',e=>{if(!searchSuggestionsEl||searchSuggestionsEl.style.display==='none'||searchSuggestionsEl.children.length===0)return;const s=Array.from(searchSuggestionsEl.children);let a=s.findIndex(i=>i.classList.contains('active'));if(e.key==='ArrowDown'){e.preventDefault();s[a]?.classList.remove('active');a=(a+1)%s.length;s[a].classList.add('active');s[a].scrollIntoView({block:'nearest'})}else if(e.key==='ArrowUp'){e.preventDefault();s[a]?.classList.remove('active');a=(a-1+s.length)%s.length;s[a].classList.add('active');s[a].scrollIntoView({block:'nearest'})}else if(e.key==='Enter'){if(a>-1){e.preventDefault();s[a].dispatchEvent(new MouseEvent('mousedown'))}}else if(e.key==='Escape'){searchSuggestionsEl.innerHTML='';searchSuggestionsEl.style.display='none'}});document.addEventListener('keydown',handleGlobalKeyDown);setSpeedDialStatus("Por favor, selecione a pasta 'Nucleo'.")});
+    searchInputEl.addEventListener('input',handleSearchInput);
+    searchInputEl.addEventListener('blur',e=>{setTimeout(()=>{if(!searchSuggestionsEl||!document.activeElement||!document.activeElement.closest('#search-suggestions')){if(searchSuggestionsEl){searchSuggestionsEl.innerHTML='';searchSuggestionsEl.style.display='none'}}},150)});
+    document.addEventListener('click',hideSuggestionsOnClickOutside);
+    searchInputEl.setAttribute('autocomplete','off');
+    searchInputEl.disabled=true; // Initially disabled until folder is loaded
+    searchInputEl.addEventListener('keydown',e=>{if(!searchSuggestionsEl||searchSuggestionsEl.style.display==='none'||searchSuggestionsEl.children.length===0)return;const s=Array.from(searchSuggestionsEl.children);let a=s.findIndex(i=>i.classList.contains('active'));if(e.key==='ArrowDown'){e.preventDefault();s[a]?.classList.remove('active');a=(a+1)%s.length;s[a].classList.add('active');s[a].scrollIntoView({block:'nearest'})}else if(e.key==='ArrowUp'){e.preventDefault();s[a]?.classList.remove('active');a=(a-1+s.length)%s.length;s[a].classList.add('active');s[a].scrollIntoView({block:'nearest'})}else if(e.key==='Enter'){if(a>-1){e.preventDefault();s[a].dispatchEvent(new MouseEvent('mousedown'))}}else if(e.key==='Escape'){searchSuggestionsEl.innerHTML='';searchSuggestionsEl.style.display='none'}});
+    document.addEventListener('keydown',handleGlobalKeyDown);
+    setSpeedDialStatus("Por favor, selecione a pasta 'Nucleo'.")
+});
 </script>
 </body>
 </html>

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,141 @@
+// worker.js
+
+// Constants (ensure these are consistent with the main script)
+const CAPAS_FOLDER_NAME = 'Capas';
+const ORIGINAIS_FOLDER_NAME = 'Originais';
+const CAMINHO_FOLDER_NAMES = ['CAMINHO1', 'CAMINHO2', 'CAMINHO3', 'CAMINHO4', 'CAMINHO5'];
+const MEDIA_FILE_EXTENSIONS = ['.mp4', '.mkv', '.avi', '.mov', '.wmv', '.flv', '.webm', '.mpeg', '.mpg', '.m4v'];
+
+// Helper functions (adapted from main script)
+function isMediaFile(fileName) {
+    if (!fileName || typeof fileName !== 'string') return false;
+    return MEDIA_FILE_EXTENSIONS.some(ext => fileName.toLowerCase().endsWith(ext));
+}
+
+function getFirstTwoWords(text) {
+    if (!text) return "";
+    const words = text.trim().split(/\s+/);
+    return words.slice(0, 2).join(" ");
+}
+
+// Main processing logic
+self.onmessage = function(event) {
+    const { filesData, rootDirName, signal } = event.data;
+
+    if (signal) {
+        signal.addEventListener('abort', () => {
+            // console.log('Worker: Abort signal received. Terminating.');
+            self.postMessage({ type: 'aborted' });
+            self.close(); // Terminate the worker
+        });
+    }
+
+    const mediaFiles = [];
+    const mediaIndex = new Map();
+    let processedCount = 0;
+
+    try {
+        if (!filesData || !rootDirName) {
+            throw new Error("Worker: Missing filesData or rootDirName");
+        }
+
+        // console.log(`Worker: Received ${filesData.length} files to process. Root: ${rootDirName}`);
+
+        for (let i = 0; i < filesData.length; i++) {
+            if (signal && signal.aborted) {
+                // console.log("Worker: Operation aborted during file processing loop.");
+                self.postMessage({ type: 'aborted' });
+                return; // Exit if aborted
+            }
+
+            const fileData = filesData[i];
+            const fullPath = fileData.webkitRelativePath;
+
+            if (!isMediaFile(fileData.name)) {
+                // console.log(`Worker: Skipping non-media file: ${fileData.name}`);
+                continue;
+            }
+
+            const pathParts = fullPath.split('/');
+            // pathParts[0] is the rootDirName, so media content starts from pathParts[1]
+            if (pathParts.length < 2) {
+                // console.log(`Worker: Skipping file not in a subdirectory (e.g., directly in root): ${fullPath}`);
+                continue; 
+            }
+            
+            const mediaGroupName = pathParts[1];
+            const isCoverFile = pathParts.includes(CAPAS_FOLDER_NAME);
+            const isOriginal = pathParts.includes(ORIGINAIS_FOLDER_NAME);
+            const isCaminho = CAMINHO_FOLDER_NAMES.some(folder => pathParts.includes(folder));
+
+            // Determine the primary name for indexing (e.g., movie name)
+            // This will be the name of the folder directly inside the rootDirName
+            const indexKey = mediaGroupName;
+
+            // console.log(`Worker: Processing ${fullPath}, indexKey: ${indexKey}, isCover: ${isCoverFile}, isOriginal: ${isOriginal}`);
+
+            const fileEntry = {
+                name: fileData.name,
+                relativePath: fullPath, // Main thread will use this to get File object
+                mediaGroupName: mediaGroupName,
+                isCoverFile: isCoverFile,
+                isOriginal: isOriginal,
+                isCaminho: isCaminho,
+                firstTwoWords: getFirstTwoWords(mediaGroupName)
+            };
+            mediaFiles.push(fileEntry);
+
+            if (!mediaIndex.has(indexKey)) {
+                mediaIndex.set(indexKey, {
+                    name: indexKey,
+                    files: [],
+                    coverFile: null,
+                    originalFiles: [],
+                    firstTwoWords: getFirstTwoWords(indexKey)
+                });
+            }
+
+            const existingEntry = mediaIndex.get(indexKey);
+            existingEntry.files.push(fileEntry);
+
+            if (isCoverFile && !existingEntry.coverFile) {
+                existingEntry.coverFile = fileEntry;
+            }
+            if (isOriginal) {
+                existingEntry.originalFiles.push(fileEntry);
+            }
+            
+            processedCount++;
+            if (processedCount % 100 === 0) { // Optional: Send progress update
+                self.postMessage({ type: 'progress', processed: processedCount, total: filesData.length });
+            }
+        }
+
+        // console.log("Worker: Processing complete.");
+        // console.log("Worker: mediaFiles count:", mediaFiles.length);
+        // console.log("Worker: mediaIndex size:", mediaIndex.size);
+        // mediaIndex.forEach((value, key) => {
+        //    console.log(`Worker: Index Key: ${key}, Files: ${value.files.length}, Cover: ${value.coverFile ? value.coverFile.name : 'None'}`);
+        // });
+
+
+        self.postMessage({
+            type: 'result',
+            mediaFiles: mediaFiles,
+            mediaIndex: mediaIndex // Maps are structured cloneable
+        });
+
+    } catch (error) {
+        console.error('Error in Web Worker:', error);
+        self.postMessage({ type: 'error', message: error.message, stack: error.stack });
+    } finally {
+        // console.log("Worker: Closing self.");
+        // self.close(); // Worker is done with its task, it can be closed.
+        // Re-consider self.close() if the worker needs to handle multiple messages over time
+        // For this specific task, after processing one batch, it's likely done.
+        // However, if we want to reuse the worker for subsequent folder selections without re-creation,
+        // then we should not self.close() here. The main thread will terminate it if needed.
+    }
+};
+
+// console.log("Worker: worker.js loaded and ready.");


### PR DESCRIPTION
This commit introduces several optimizations to improve performance when handling very large media libraries (60,000+ files).

Key changes:

1.  **Background File Processing:**
    *   I now handle the expensive tasks of iterating through your selected file list, extracting metadata (like prefixes from filenames), and building the necessary data structures in the background.
    *   This moves heavy processing off the main thread, preventing the UI from freezing during initial folder selection and subsequent processing.
    *   The main script now initializes this background process, sends file data to it, and receives the processed metadata and index asynchronously.
    *   Loading indicators and UI states are updated based on messages from this background process.

2.  **Optimized Data Handling:**
    *   Functions like `handleFolderSelection`, `processAndDisplayFilesForPath`, `displayGlobalMediaByPrefix`, `handleSearchInput`, and `loadBlobForItem` have been refactored to work with the data structures populated by the background process.
    *   `displayGlobalMediaByPrefix` now uses background-processed metadata, making it more efficient than iterating through the entire raw file list.

3.  **Resource Management:**
    *   `revokeItemResources` has been updated to correctly handle the metadata objects received from the background process.

**Impact:**
*   The application should now be significantly more responsive during initial load and when processing large folders.
*   The UI should no longer lock up when a directory with tens of thousands of files is selected.

An attempt to implement full DOM virtualization for the media display was made but could not be completed due to technical complexities and limitations within the allotted development time. Despite this, the introduction of background processing is a substantial improvement for the described performance bottlenecks.