### PR TITLE
feat: Adiciona botão de download em massa na visualização de tópicos

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,8 @@
         "https://forum.candidgirls.io/unseen*",
         "https://forum.candidgirls.io/unread*",
         "https://forum.candidgirls.io/c/*",
-        "https://forum.candidgirls.io/search*"
+        "https://forum.candidgirls.io/search*",
+        "https://forum.candidgirls.io/t/*"
       ],
       "js": ["content_script.js"],
       "run_at": "document_idle"


### PR DESCRIPTION
- Atualiza o manifest.json para permitir a execução do script de conteúdo nas páginas de tópico (/t/*).
- Adiciona lógica no content_script.js para injetar um botão 'Baixar Tudo' na área de ações do tópico.
- O botão reutiliza a funcionalidade de galeria existente para buscar todas as imagens do tópico e iniciar o download em massa.